### PR TITLE
Made the workflow name optional

### DIFF
--- a/api/workflow.js
+++ b/api/workflow.js
@@ -17,18 +17,20 @@ function WorkflowClient(jiraClient) {
      * @method getWorkflows
      * @memberOf WorkflowClient#
      * @param {Object} opts The request options sent to the Jira API
-     * @param {string} [opts.workflowName] The name of the workflow to retrieve.
+     * @param {string} (optional) [opts.workflowName] The name of the workflow to retrieve.
      * @param callback Called when the workflow(s) have been retrieved.
      */
     this.getWorkflows = function (opts, callback) {
+        var qs = {};
+        if (opts && typeof opts === 'object' && opts.hasOwnProperty(workflowName)) {
+            qs.workflowName = opts.workflowName;
+        }
         var options = {
             uri: this.jiraClient.buildURL('/workflow'),
             method: 'GET',
             json: true,
             followAllRedirects: true,
-            qs: {
-                workflowName: opts.workflowName
-            }
+            qs: qs
         };
 
         this.jiraClient.makeRequest(options, callback);


### PR DESCRIPTION
The method is called getWorkflows (plural) and should, therefore, allow for the retrieval of all workflow if  workflow name is omitted. This fix will allow that.

Thanks!