### PR TITLE
Make workflow name optional

### DIFF
--- a/api/workflow.js
+++ b/api/workflow.js
@@ -21,14 +21,16 @@ function WorkflowClient(jiraClient) {
      * @param callback Called when the workflow(s) have been retrieved.
      */
     this.getWorkflows = function (opts, callback) {
+        var qs = {};
+        if (opts && typeof opts === 'object' && opts.hasOwnProperty('workflowName')) {
+            qs.workflowName = opts.workflowName;
+        }
         var options = {
             uri: this.jiraClient.buildURL('/workflow'),
             method: 'GET',
             json: true,
             followAllRedirects: true,
-            qs: {
-                workflowName: opts.workflowName
-            }
+            qs: qs
         };
 
         this.jiraClient.makeRequest(options, callback);


### PR DESCRIPTION
This will allow a user to get a list of all workflows (not previously permitted) OR details of a specific workflow.