### PR TITLE
Allow Jira to exist somewhere other than "/" in the URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ var workflowScheme = require('./api/workflowScheme');
  * @param {string} config.host The hostname of the Jira API.
  * @param {string} [config.protocol=https] The protocol used to accses the Jira API.
  * @param {number} [config.port=443] The port number used to connect to Jira.
+ * @param {string} [config.path_prefix="/"] The prefix to use in front of the path, if Jira isn't at "/"
  * @param {string} [config.version=2] The version of the Jira API to which you will be connecting.  Currently, only
  *     version 2 is supported.
  * @param config.auth The authentication information used tp connect to Jira. Must contain EITHER username and password
@@ -123,6 +124,7 @@ var JiraClient = module.exports = function (config) {
     }
     this.host = config.host;
     this.protocol = config.protocol ? config.protocol : 'https';
+    this.path_prefix = config.path_prefix ? config.path_prefix : '/';
     this.port = config.port;
     this.apiVersion = 2; // TODO Add support for other versions.
 
@@ -217,7 +219,7 @@ var JiraClient = module.exports = function (config) {
      * @returns {string} The constructed URL.
      */
     this.buildURL = function (path) {
-        var apiBasePath = 'rest/api/';
+        var apiBasePath = this.path_prefix + 'rest/api/';
         var version = this.apiVersion;
         var requestUrl = url.format({
             protocol: this.protocol,

--- a/lib/oauth_util.js
+++ b/lib/oauth_util.js
@@ -21,6 +21,7 @@ var errorStrings = require('./error');
  * @param {string} config.host The hostname of the Jira API.
  * @param {string} [config.protocol=https] - The protocol used to accses the Jira API.
  * @param {number} [config.port=443] - The port number used to connect to Jira.
+ * @param {string} [config.path_prefix="/"] The prefix to use in front of the path, if Jira isn't at "/"
  * @param {string} [config.version=2] - The version of the Jira API to which you will be connecting.  Currently, only
  *     version 2 is supported.
  * @param {Object} config.oauth The oauth information
@@ -32,8 +33,9 @@ var errorStrings = require('./error');
  * @param {OauthUtil~getOauthUrlCallback} callback The function called when the URL has been retrieved.
  */
 exports.getAuthorizeURL = function (config, callback) {
+    var prefix = config.path_prefix ? config.path_prefix : '/';
     var AUTH_TOKEN_APPEND = '/oauth/authorize';
-    var SERVLET_BASE_URL = '/plugins/servlet';
+    var SERVLET_BASE_URL = prefix + '/plugins/servlet';
 
     var authURL = url.format({
         protocol: config.protocol ? config.protocol : 'https',
@@ -93,6 +95,7 @@ exports.swapRequestTokenWithAccessToken = function(config, callback) {
  * @param {string} config.host The hostname of the Jira API.
  * @param {string} [config.protocol=https] - The protocol used to accses the Jira API.
  * @param {number} [config.port=443] - The port number used to connect to Jira.
+ * @param {string} [config.path_prefix="/"] The prefix to use in front of the path, if Jira isn't at "/"
  * @param {string} [config.version=2] - The version of the Jira API to which you will be connecting.  Currently, only
  *     version 2 is supported.
  * @param {Object} config.oauth The oauth information
@@ -105,7 +108,8 @@ exports.swapRequestTokenWithAccessToken = function(config, callback) {
  * @returns {exports.OAuth} The generated object.
  */
 function generateOAuthObject(config) {
-    var SERVLET_BASE_URL = '/plugins/servlet';
+    var prefix = config.path_prefix ? config.path_prefix : '/';
+    var SERVLET_BASE_URL = prefix + '/plugins/servlet';
     var REQ_TOKEN_APPEND = '/oauth/request-token';
 
     var ACCESS_TOKEN_APPEND = '/oauth/access-token';


### PR DESCRIPTION
We have Jira hosted at "/jira/" and reverse-proxied, this PR allows it to exist somewhere other than "/" by setting a "path_prefix" config field when instantiating the JiraClient (and when doing the OAuth calls).