### PR TITLE
Remove slash from prefix

### DIFF
--- a/lib/oauth_util.js
+++ b/lib/oauth_util.js
@@ -33,7 +33,7 @@ var errorStrings = require('./error');
  * @param {OauthUtil~getOauthUrlCallback} callback The function called when the URL has been retrieved.
  */
 exports.getAuthorizeURL = function (config, callback) {
-    var prefix = config.path_prefix ? config.path_prefix : '/';
+    var prefix = config.path_prefix ? config.path_prefix : '';
     var AUTH_TOKEN_APPEND = '/oauth/authorize';
     var SERVLET_BASE_URL = prefix + '/plugins/servlet';
 
@@ -108,7 +108,7 @@ exports.swapRequestTokenWithAccessToken = function(config, callback) {
  * @returns {exports.OAuth} The generated object.
  */
 function generateOAuthObject(config) {
-    var prefix = config.path_prefix ? config.path_prefix : '/';
+    var prefix = config.path_prefix ? config.path_prefix : '';
     var SERVLET_BASE_URL = prefix + '/plugins/servlet';
     var REQ_TOKEN_APPEND = '/oauth/request-token';
 


### PR DESCRIPTION
 The prefix breaks the request for the Oauth token, just leave it empty and all is fine.