### PR TITLE
Fix: issue.addComment - wrap opts.comment in {body: comment}

### DIFF
--- a/api/issue.js
+++ b/api/issue.js
@@ -270,7 +270,7 @@ function IssueClient(jiraClient) {
      * @param callback
      */
     this.addComment = function (opts, callback) {
-        var options = this.buildRequestOptions(opts, '/comment', 'POST', opts.comment);
+        var options = this.buildRequestOptions(opts, '/comment', 'POST', {body: opts.comment});
 
         this.jiraClient.makeRequest(options, callback);
     };


### PR DESCRIPTION
https://docs.atlassian.com/jira/REST/6.4/
/rest/api/2/issue/{issueIdOrKey}/comment/{id}

requires as payload:
```
{ body: comment }
```

The same with REST 7.0