### PR TITLE
added support for query string fields on issues

### DIFF
--- a/api/issue.js
+++ b/api/issue.js
@@ -209,7 +209,7 @@ function IssueClient(jiraClient) {
         if (!opts.issue) {
             throw new Error(errorStrings.NO_ISSUE_ERROR);
         }
-        var options = this.buildRequestOptions(opts, '', 'PUT', opts.issue);
+        var options = this.buildRequestOptions(opts, '', 'PUT', opts.issue, opts.qs);
 
         this.jiraClient.makeRequest(options, callback, 'Issue Updated');
     };


### PR DESCRIPTION
With Jira v7.2.0 ([this issue](https://jira.atlassian.com/browse/JRA-34423)), you now have the ability to decide whether or not to notify users when you edit an issue through the api. To use this feature, a request needs to be made similar to the following:
`http://jrl2014s:8080/rest/api/2/issue/TEST-9?notifyUsers=false`

To resolve this, we need to pass in a value to the `qs` parameter of the `buildRequestOptions` function. This allows us to make api calls like so:
```javascript
jira.issue.editIssue({issue: {update: {labels: [{add: 'blocked'}]}}, qs: { notifyUsers: false }, issueKey: 'TEST-9'})
```