### PR TITLE
Add support for webhooks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,11 @@ is still valid!
   * deleteVersion
   * deleteAllRemoteLinks
   * getGlobalRemoteLink
+* webhook (/rest/webhooks/1.0/webhook)
+  * getAllWebhooks
+  * getWebhook
+  * createWebhook
+  * deleteWebhook
 * workflow (/rest/api/2/workflow)
   * getWorkflows
 * workflowScheme (/rest/api/2/workflowscheme)

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,0 +1,100 @@
+"use strict";
+
+module.exports = WebhookClient;
+
+/**
+ * Used to access Jira REST endpoints in '/rest/webhook/1.0/webhook'
+ *
+ * @param {JiraClient} jiraClient
+ * @constructor WebhookClient
+ */
+function WebhookClient(jiraClient) {
+    this.jiraClient = jiraClient;
+
+    /**
+     * Returns a list of all registered webhooks.
+     *
+     * @method getAllWebhooks
+     * @memberOf WebhookClient#
+     * @param opts Ignored
+     * @param callback Called when the webhooks have been retrieved.
+     */
+    this.getAllWebhooks = function (opts, callback) {
+        var options = {
+            uri: this.jiraClient.buildWebhookURL('/webhook'),
+            method: 'GET',
+            json: true,
+            followAllRedirects: true
+        };
+
+        this.jiraClient.makeRequest(options, callback);
+    };
+
+    /**
+     * Returns a webhook with a specific ID.
+     *
+     * @method getWebhook
+     * @memberOf WebhookClient#
+     * @param opts The options sent to the JIRA API.
+     * @param opts.webhookId The numerical webhook ID.
+     * @param callback Called when the webhook has been retrieved.
+     */
+    this.getWebhook = function (opts, callback) {
+        var options = {
+            uri: this.jiraClient.buildWebhookURL('/webhook/' + opts.webhookId),
+            method: 'GET',
+            json: true,
+            followAllRedirects: true
+        };
+
+        this.jiraClient.makeRequest(options, callback);
+    };
+
+    /**
+     * Registers a new webhook.
+     *
+     * @method createWebhook
+     * @memberOf WebhookClient#
+     * @param opts The options sent to the JIRA API.
+     * @param opts.name The name of the webhook.
+     * @param opts.url The URL of the webhook.
+     * @param opts.events An array of events with which the webhook should be registered. See
+     *   {@link https://developer.atlassian.com/jiradev/jira-apis/webhooks#Webhooks-configureConfiguringawebhook}.
+     * @param opts.enabled Whether the webhook is enabled.
+     * @param opts.filter An object containing filter configuration.
+     * @param opts.filter.issue-related-events-section A filter for issues, written in JQL.
+     * @param opts.excludeBody Whether to send an empty body to the webhook URL.
+     * @param callback Called when the webhook has been retrieved.
+     */
+    this.createWebhook = function (opts, callback) {
+        var options = {
+            uri: this.jiraClient.buildWebhookURL('/webhook'),
+            method: 'POST',
+            json: true,
+            body: opts,
+            followAllRedirects: true
+        };
+
+        this.jiraClient.makeRequest(options, callback);
+    };
+
+    /**
+     * Deletes a registered webhook.
+     *
+     * @method deleteWebhook
+     * @memberOf WebhookClient#
+     * @param opts The options sent to the JIRA API.
+     * @param opts.webhookId The numerical webhook ID.
+     * @param callback Called when the webhook has been retrieved.
+     */
+    this.deleteWebhook = function (opts, callback) {
+        var options = {
+            uri: this.jiraClient.buildWebhookURL('/webhook/' + opts.webhookId),
+            method: 'DELETE',
+            json: true,
+            followAllRedirects: true
+        };
+
+        this.jiraClient.makeRequest(options, callback);
+    };
+}

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ var version = require('./api/version');
 var project = require('./api/project');
 var projectCategory = require('./api/projectCategory');
 var user = require('./api/user');
+var webhook = require('./api/webhook');
 var workflowScheme = require('./api/workflowScheme');
 var worklog = require('./api/worklog');
 
@@ -97,6 +98,7 @@ var worklog = require('./api/worklog');
  * @property {ProjectClient} project
  * @property {ProjectCategoryClient} projectCategory
  * @property {UserClient} user
+ * @property {WebhookClient} webhook
  * @property {WorkflowSchemeClient} workflowScheme
  * @property {WorklogClient} worklog
  *
@@ -131,6 +133,7 @@ var JiraClient = module.exports = function (config) {
     this.port = config.port;
     this.apiVersion = 2; // TODO Add support for other versions.
     this.agileApiVersion = '1.0';
+    this.webhookApiVersion = '1.0';
 
     if (config.oauth) {
         if (!config.oauth.consumer_key) {
@@ -210,6 +213,7 @@ var JiraClient = module.exports = function (config) {
     this.project = new project(this);
     this.projectCategory = new projectCategory(this);
     this.user = new user(this);
+    this.webhook = new webhook(this);
     this.workflowScheme = new workflowScheme(this);
     this.worklog = new worklog(this);
 };
@@ -248,6 +252,27 @@ var JiraClient = module.exports = function (config) {
     this.buildAgileURL = function (path) {
         var apiBasePath = this.path_prefix + 'rest/agile/';
         var version = this.agileApiVersion;
+        var requestUrl = url.format({
+            protocol: this.protocol,
+            hostname: this.host,
+            port: this.port,
+            pathname: apiBasePath + version + path
+        });
+
+        return decodeURIComponent(requestUrl);
+    };
+
+    /**
+     * Simple utility to build a REST endpoint URL for the Jira webhook API.
+     *
+     * @method buildWebhookURL
+     * @memberOf JiraClient#
+     * @param path The path of the URL without concern for the root of the REST API.
+     * @returns {string} The constructed URL.
+     */
+    this.buildWebhookURL = function (path) {
+        var apiBasePath = this.path_prefix + 'rest/webhook/';
+        var version = this.webhookApiVersion;
         var requestUrl = url.format({
             protocol: this.protocol,
             hostname: this.host,


### PR DESCRIPTION
This PR adds support for the separate API used to view, create, and delete webhooks on Jira.