### PR TITLE
Catching JSON.parse errors within responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,7 +312,13 @@ var JiraClient = module.exports = function (config) {
                 return callback(err ? err : body, null, response);
             }
 
-            if (typeof body == 'string') body = JSON.parse(body);
+            if (typeof body == 'string') {
+                try {
+                    body = JSON.parse(body);
+                } catch (jsonErr) {
+                    return callback(jsonErr, null, response);
+                }
+            }
 
             return callback(null, successString ? successString : body, response);
         });


### PR DESCRIPTION
Wrapping the JSON.parse within the jira connector's response handling so that invalid JSON responses do not trigger unhandled exceptions

PTAL @floralvikings 

CC @vaskevich 