### PR TITLE
Maintain headers when using base64 basic auth ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,9 +302,10 @@ var JiraClient = module.exports = function (config) {
             options.oauth = this.oauthConfig;
         } else if (this.basic_auth) {
             if (this.basic_auth.base64) {
-              options.headers = {
-                Authorization: 'Basic ' + this.basic_auth.base64
+              if (!options.headers) {
+                options.headers = {}
               }
+              options.headers['Authorization'] = 'Basic ' + this.basic_auth.base64
             } else {
               options.auth = this.basic_auth;
             }


### PR DESCRIPTION
... otherwise operations that need extra headers don’t work like “issue.addAttachment”.