### PR TITLE
Promise support.

### DIFF
--- a/api/application-properties.js
+++ b/api/application-properties.js
@@ -20,7 +20,8 @@ function ApplicationPropertiesClient(jiraClient) {
      * @param [opts.keyFilter] When fetching a list allows the list to be filtered by the property's start of key e.g.
      *     "jira.lf.*" whould fetch only those permissions that are editable and whose keys start with "jira.lf.". This
      *     is a regex
-     * @param callback Called when the properties are retrieved.
+     * @param [callback] Called when the properties are retrieved.
+     * @return {Promise} Resolved when the properties are retrieved.
      */
     this.getProperties = function (opts, callback) {
         var qs = {};
@@ -43,7 +44,7 @@ function ApplicationPropertiesClient(jiraClient) {
             qs: qs
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -55,7 +56,8 @@ function ApplicationPropertiesClient(jiraClient) {
      * @param opts.id The id of the property to be modified
      * @param opts.property The new data for the property.  See
      *     {@link https://docs.atlassian.com/jira/REST/latest/#d2e4891}
-     * @param callback Called when the property has been modified
+     * @param [callback] Called when the property has been modified
+     * @return {Promise} Resolved when the property has been modified
      */
     this.setProperty = function (opts, callback) {
         var options = {
@@ -65,6 +67,6 @@ function ApplicationPropertiesClient(jiraClient) {
             body: opts.property
         };
 
-        this.jiraClient.makeRequest(options, callback, 'Property Updated');
+        return this.jiraClient.makeRequest(options, callback, 'Property Updated');
     };
 }

--- a/api/attachment.js
+++ b/api/attachment.js
@@ -20,7 +20,8 @@ function AttachmentClient(jiraClient) {
      * @memberOf AttachmentClient#
      * @param opts The options for the API request.
      * @param opts.attachmentId The id of the attachment to retrieve
-     * @param callback Called when the attachment metadata is retrieved.
+     * @param [callback] Called when the attachment metadata is retrieved.
+     * @return {Promise} Resolved when the attachment metadata is retrieved.
      */
     this.getAttachment = function (opts, callback) {
         if (!opts.attachmentId) {
@@ -34,7 +35,7 @@ function AttachmentClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -44,7 +45,8 @@ function AttachmentClient(jiraClient) {
      * @memberOf AttachmentClient#
      * @param opts The options for the API request.
      * @param opts.attachmentId The id of the attachment to delete
-     * @param callback Called when the attachment is deleted.
+     * @param [callback] Called when the attachment is deleted.
+     * @return {Promise} Resolved when the attachment is deleted.
      */
     this.deleteAttachment = function (opts, callback) {
         if (!opts.attachmentId) {
@@ -58,7 +60,7 @@ function AttachmentClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback, 'Attachment Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Attachment Deleted');
     };
 
 
@@ -69,7 +71,8 @@ function AttachmentClient(jiraClient) {
      * @method getGlobalAttachmentMetadata
      * @memberOf AttachmentClient#
      * @param opts This API request actually takes no options; this parameter is ignored.
-     * @param callback Called when the metadata is retrieved.
+     * @param [callback] Called when the metadata is retrieved.
+     * @return {Promise} Resolved when the metadata is retrieved.
      */
     this.getGlobalAttachmentMetadata = function (opts, callback) {
         var options = {
@@ -79,6 +82,6 @@ function AttachmentClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/auditing.js
+++ b/api/auditing.js
@@ -29,7 +29,8 @@ function AuditingClient(jiraClient) {
      * @param [opts.to] Timestamp in past; 'from' must be less or equal 'to', otherwise the result set will be empty
      *     only records that where created in the same moment or earlier than the 'to' timestamp will be provided in
      *     response
-     * @param callback Called when the audits are retrieved.
+     * @param [callback] Called when the audits are retrieved.
+     * @return {Promise} Resolved when the audits are retrieved.
      */
     this.getAudits = function (opts, callback) {
         var options = {
@@ -46,7 +47,7 @@ function AuditingClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -55,7 +56,8 @@ function AuditingClient(jiraClient) {
      * @memberOf AuditingClient#
      * @param opts The request options.
      * @param opts.audit See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2557}
-     * @param callback Called when the audit is created.
+     * @param [callback] Called when the audit is created.
+     * @return {Promise} Resolved when the audit is created.
      */
     this.createAudit = function (opts, callback) {
         if (!opts.audit) {
@@ -70,6 +72,6 @@ function AuditingClient(jiraClient) {
             body: opts.audit
         };
 
-        this.jiraClient.makeRequest(options, callback, 'Audit Record Added');
+        return this.jiraClient.makeRequest(options, callback, 'Audit Record Added');
     };
 }

--- a/api/avatar.js
+++ b/api/avatar.js
@@ -21,7 +21,8 @@ function AvatarClient(jiraClient) {
      * @memberOf AvatarClient#
      * @param opts The options to be used in the API request.
      * @param opts.avatarType The avatar type.  May be 'project' or 'user'.
-     * @param callback Called when the avatars are retrieved.
+     * @param [callback] Called when the avatars are retrieved.
+     * @return {Promise} Resolved when the avatars are retrieved.
      */
     this.getAvatars = function (opts, callback) {
         if (!opts.avatarType) {
@@ -34,7 +35,7 @@ function AvatarClient(jiraClient) {
             uri: this.jiraClient.buildURL('/avatar/' + opts.avatarType + '/system')
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -48,7 +49,8 @@ function AvatarClient(jiraClient) {
      * @param opts.avatarFilename The name of the file being uploaded
      * @param opts.avatarFileSize The size of the file
      * @param opts.avatarFilePath The path to the avatar file.
-     * @param callback Called when the avatar is created.
+     * @param [callback] Called when the avatar is created.
+     * @return {Promise} Resolved when the avatar is created.
      */
     this.createTemporaryAvatar = function (opts, callback) {
         if (!opts.avatarType) {
@@ -74,7 +76,7 @@ function AvatarClient(jiraClient) {
         };
         delete options.body;
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -86,7 +88,8 @@ function AvatarClient(jiraClient) {
      * @param {Object} opts The options to be used in the API request.
      * @param {string} opts.avatarType The avatar type.  May be 'project' or 'user'.
      * @param {Object} opts.crop See {@link https://docs.atlassian.com/jira/REST/latest/#d2e3316}
-     * @param callback Called when the avatar has been cropped.
+     * @param [callback] Called when the avatar has been cropped.
+     * @return {Promise} Resolved when the avatar has been cropped.
      */
     this.cropTemporaryAvatar = function (opts, callback) {
         if (!opts.avatarType) {
@@ -104,6 +107,6 @@ function AvatarClient(jiraClient) {
             body: opts.crop
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/board.js
+++ b/api/board.js
@@ -24,7 +24,8 @@ function AgileBoardClient(jiraClient) {
    *     provides, dues to lack or resources or any other condition. When this happens, your results will be
    *     truncated. Callers should always check the returned maxResults to determine the value that is effectively
    *     being used.
-   * @param callback Called when the dashboards have been retrieved.
+   * @param [callback] Called when the dashboards have been retrieved.
+   * @return {Promise} Resolved when the dashboards have been retrieved.
    */
   this.getAllBoards = function (opts, callback) {
     var options = {
@@ -39,7 +40,7 @@ function AgileBoardClient(jiraClient) {
       }
     };
 
-    this.jiraClient.makeRequest(options, callback);
+      return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -49,7 +50,8 @@ function AgileBoardClient(jiraClient) {
    * @memberOf AgileBoardClient#
    * @param opts The request options sent to the Jira API.
    * @param opts.boardId The agile board id.
-   * @param callback Called when the dashboard has been retrieved
+   * @param [callback] Called when the dashboard has been retrieved
+   * @return {Promise} Resolved when the dashboard has been retrieved
    */
   this.getBoard = function (opts, callback) {
     var options = {
@@ -64,7 +66,7 @@ function AgileBoardClient(jiraClient) {
       }
     };
 
-    this.jiraClient.makeRequest(options, callback);
+      return this.jiraClient.makeRequest(options, callback);
   };
 
 
@@ -82,7 +84,8 @@ function AgileBoardClient(jiraClient) {
    *     provides, dues to lack or resources or any other condition. When this happens, your results will be
    *     truncated. Callers should always check the returned maxResults to determine the value that is effectively
    *     being used.
-   * @param callback Called when the dashboards have been retrieved.
+   * @param [callback] Called when the dashboards have been retrieved.
+   * @return {Promise} Resolved when the dashboards have been retrieved.
    */
   this.getIssuesForBoard = function (opts, callback) {
     var options = {
@@ -96,6 +99,6 @@ function AgileBoardClient(jiraClient) {
       }
     };
 
-    this.jiraClient.makeRequest(options, callback);
+      return this.jiraClient.makeRequest(options, callback);
   };
 }

--- a/api/comment.js
+++ b/api/comment.js
@@ -19,11 +19,12 @@ function CommentClient(jiraClient) {
      * @memberOf CommentClient#
      * @param opts The options passed in the request to the API.
      * @param opts.commentId The id of the comment from which keys will be returned.
-     * @param callback Called when the keys have been retrieved.
+     * @param [callback] Called when the keys have been retrieved.
+     * @return {Promise} Resolved when the keys have been retrieved.
      */
     this.getCommentPropertyKeys = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -38,7 +39,8 @@ function CommentClient(jiraClient) {
      * @param opts.commentId The id of the comment from which keys will be returned.
      * @param opts.propertyKey The key of the property to be edited.
      * @param opts.propertyValue The new value of the property.
-     * @param callback Called when the property has been edited.
+     * @param [callback] Called when the property has been edited.
+     * @return {Promise} Resolved when the property has been edited.
      */
     this.setCommentProperty = function (opts, callback) {
         if (!opts.propertyKey) {
@@ -47,7 +49,7 @@ function CommentClient(jiraClient) {
             throw new Error(errorStrings.NO_COMMENT_PROPERTY_VALUE_ERROR);
         }
         var options = this.buildRequestOptions(opts, '/' + opts.propertyKey, 'PUT', opts.propertyValue);
-        this.jiraClient.makeRequest(options, callback, 'Property Edited');
+        return this.jiraClient.makeRequest(options, callback, 'Property Edited');
     };
 
     /**
@@ -59,14 +61,15 @@ function CommentClient(jiraClient) {
      * @param opts The options passed in the request to the API.
      * @param opts.commentId The id of the comment from which keys will be returned.
      * @param opts.propertyKey The key of the property to be edited.
-     * @param callback Called when the property has been retrieved.
+     * @param [callback] Called when the property has been retrieved.
+     * @return {Promise} Resolved when the property has been retrieved.
      */
     this.getCommentProperty = function (opts, callback) {
         if (!opts.propertyKey) {
             throw new Error(errorStrings.NO_COMMENT_PROPERTY_KEY_ERROR);
         }
         var options = this.buildRequestOptions(opts, '/' + opts.propertyKey, 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -78,14 +81,15 @@ function CommentClient(jiraClient) {
      * @param opts The options passed in the request to the API.
      * @param opts.commentId The id of the comment from which keys will be returned.
      * @param opts.propertyKey The key of the property to be edited.
-     * @param callback Called when the property has been retrieved.
+     * @param [callback] Called when the property has been retrieved.
+     * @return {Promise} Resolved when the property has been retrieved.
      */
     this.deleteCommentProperty = function (opts, callback) {
         if (!opts.propertyKey) {
             throw new Error(errorStrings.NO_COMMENT_PROPERTY_KEY_ERROR);
         }
         var options = this.buildRequestOptions(opts, '/' + opts.propertyKey, 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Comment property deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Comment property deleted');
     };
 
     /**

--- a/api/component.js
+++ b/api/component.js
@@ -18,7 +18,8 @@ function ComponentClient(jiraClient) {
      * @memberOf ComponentClient#
      * @param opts The request options sent to the Jira API
      * @param opts.component See {@link https://docs.atlassian.com/jira/REST/latest/#d2e3871}
-     * @param callback Called when the component has been created.
+     * @param [callback] Called when the component has been created.
+     * @return {Promise} Resolved when the component has been created.
      */
     this.createComponent = function (opts, callback) {
         var options = {
@@ -29,7 +30,7 @@ function ComponentClient(jiraClient) {
             body: opts.component
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -43,7 +44,8 @@ function ComponentClient(jiraClient) {
      * @param opts.id The id of the component to edit.
      * @param opts.component The new data to place in the component.  See
      *      {@link https://docs.atlassian.com/jira/REST/latest/#d2e3939}
-     * @param callback Called when the component has beed edited.
+     * @param [callback] Called when the component has beed edited.
+     * @return {Promise} Resolved when the component has beed edited.
      */
     this.editComponent = function (opts, callback) {
         var options = {
@@ -54,7 +56,7 @@ function ComponentClient(jiraClient) {
             body: opts.component
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -64,7 +66,8 @@ function ComponentClient(jiraClient) {
      * @memberOf ComponentClient#
      * @param opts The options sent to the Jira API
      * @param opts.id The id of the component to edit.
-     * @param callback Called when the component has been retrieved.
+     * @param [callback] Called when the component has been retrieved.
+     * @return {Promise} Resolved when the component has been retrieved.
      */
     this.getComponent = function (opts, callback) {
         var options = {
@@ -74,7 +77,7 @@ function ComponentClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -86,7 +89,8 @@ function ComponentClient(jiraClient) {
      * @param opts.id The id of the component to edit.
      * @param [opts.moveIssuesTo] The new component applied to issues whose 'id' component will be deleted. If this
      *     value is null, then the 'id' component is simply removed from the related isues.
-     * @param callback Called when the component has been deleted.
+     * @param [callback] Called when the component has been deleted.
+     * @return {Promise} Resolved when the component has been deleted.
      */
     this.deleteComponent = function (opts, callback) {
         var options = {
@@ -96,7 +100,7 @@ function ComponentClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback, 'Project Component Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Project Component Deleted');
     };
 
     /**
@@ -106,7 +110,8 @@ function ComponentClient(jiraClient) {
      * @memberOf ComponentClient#
      * @param opts The options sent to the Jira API
      * @param opts.id The id of the component to edit.
-     * @param callback Called when the count has been retrieved.
+     * @param [callback] Called when the count has been retrieved.
+     * @return {Promise} Resolved when the count has been retrieved.
      */
     this.getRelatedIssueCounts = function (opts, callback) {
         var options = {
@@ -116,6 +121,6 @@ function ComponentClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/customFieldOption.js
+++ b/api/customFieldOption.js
@@ -20,7 +20,8 @@ function CustomFieldOptionClient(jiraClient) {
      * @memberOf CustomFieldOptionClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.fieldOptionId A String containing an Custom Field Option id
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.getCustomFieldOption = function (opts, callback) {
         if (!opts.fieldOptionId) {
@@ -34,6 +35,6 @@ function CustomFieldOptionClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/dashboard.js
+++ b/api/dashboard.js
@@ -26,7 +26,8 @@ function DashboardClient(jiraClient) {
      *     provides, dues to lack or resources or any other condition. When this happens, your results will be
      *     truncated. Callers should always check the returned maxResults to determine the value that is effectively
      *     being used.
-     * @param callback Called when the dashboards have been retrieved.
+     * @param [callback] Called when the dashboards have been retrieved.
+     * @return {Promise} Resolved when the dashboards have been retrieved.
      */
     this.getAllDashboards = function (opts, callback) {
         var options = {
@@ -41,7 +42,7 @@ function DashboardClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -51,7 +52,8 @@ function DashboardClient(jiraClient) {
      * @memberOf DashboardClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.dashboardId The dashboard id.
-     * @param callback Called when the dashboard has been retrieved
+     * @param [callback] Called when the dashboard has been retrieved
+     * @return {Promise} Resolved when the dashboard has been retrieved
      */
     this.getDashboard = function (opts, callback) {
         var options = {
@@ -66,6 +68,6 @@ function DashboardClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/field.js
+++ b/api/field.js
@@ -17,7 +17,8 @@ function FieldClient(jiraClient) {
      * @method getAllFields
      * @memberOf FieldClient#
      * @param opts Ignored
-     * @param callback Called when the fields have been retrieved.
+     * @param [callback] Called when the fields have been retrieved.
+     * @return {Promise} Resolved when the fields have been retrieved.
      */
     this.getAllFields = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function FieldClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function FieldClient(jiraClient) {
      * @memberOf FieldClient#
      * @param opts The request options to send to Jira
      * @param opts.field See {@link https://docs.atlassian.com/jira/REST/latest/#d2e3412}
-     * @param callback Called when the custom field has been created.
+     * @param [callback] Called when the custom field has been created.
+     * @return {Promise} Resolved when the custom field has been created.
      */
     this.createCustomField = function (opts, callback) {
         var options = {
@@ -48,6 +50,6 @@ function FieldClient(jiraClient) {
             body: opts.field
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/filter.js
+++ b/api/filter.js
@@ -21,7 +21,8 @@ function FilterClient(jiraClient) {
      * @param {Array} [opts.expand] The parameters to expand.
      * @param {Object} opts.filter The filter to create.  See
      *      {@link https://docs.atlassian.com/jira/REST/latest/#d2e3347}
-     * @param callback Called when the filter has been created.
+     * @param [callback] Called when the filter has been created.
+     * @return {Promise} Resolved when the filter has been created.
      */
     this.createFilter = function (opts, callback) {
         var options = {
@@ -40,7 +41,7 @@ function FilterClient(jiraClient) {
             });
         }
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -50,11 +51,12 @@ function FilterClient(jiraClient) {
      * @memberOf FilterClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.filterId The id of the filter to retrieve
-     * @param callback Called when the filter has been retrieved.
+     * @param [callback] Called when the filter has been retrieved.
+     * @return {Promise} Resolved when the filter has been retrieved.
      */
     this.getFilter = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -66,11 +68,12 @@ function FilterClient(jiraClient) {
      * @param {number} opts.filterId The id of the filter to update
      * @param {Object} opts.filter The new data for the filter.  See
      *      {@link https://docs.atlassian.com/jira/REST/latest/#d2e3401}
-     * @param callback Called when the filter has been updated.
+     * @param [callback] Called when the filter has been updated.
+     * @return {Promise} Resolved when the filter has been updated.
      */
     this.updateFilter = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'PUT', opts.filter);
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -80,11 +83,12 @@ function FilterClient(jiraClient) {
      * @memberOf FilterClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.filterId The id of the filter to delete
-     * @param callback Called when the filter has been deleted.
+     * @param [callback] Called when the filter has been deleted.
+     * @return {Promise} Resolved when the filter has been deleted.
      */
     this.deleteFilter = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Filter Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Filter Deleted');
     };
 
     /**
@@ -95,11 +99,12 @@ function FilterClient(jiraClient) {
      * @memberOf FilterClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.filterId The id of the filter for which to retrieve columns.
-     * @param callback Called when the columns have been retrieved.
+     * @param [callback] Called when the columns have been retrieved.
+     * @return {Promise} Resolved when the columns have been retrieved.
      */
     this.getFilterColumns = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/columns', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -111,12 +116,13 @@ function FilterClient(jiraClient) {
      * @param {number} opts.filterId The id of the filter for which to update columns.
      * @param {Array} opts.columns The names of the new columns.
      *      See {@link https://docs.atlassian.com/jira/REST/latest/#d2e3460}
-     * @param callback Called when the columns have been set
+     * @param [callback] Called when the columns have been set
+     * @return {Promise} Resolved when the columns have been set
      */
     this.setFilterColumns = function (opts, callback) {
         var body = {columns: opts.columns};
         var options = this.buildRequestOptions(opts, '/columns', 'PUT', body);
-        this.jiraClient.makeRequest(options, callback, 'Columns Updated');
+        return this.jiraClient.makeRequest(options, callback, 'Columns Updated');
     };
 
     /**
@@ -126,11 +132,12 @@ function FilterClient(jiraClient) {
      * @memberOf FilterClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.filterId The id of the filter for which to reset columns.
-     * @param callback Called when the columns have been reset.
+     * @param [callback] Called when the columns have been reset.
+     * @return {Promise} Resolved when the columns have been reset.
      */
     this.resetFilterColumns = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/columns', 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Columns Reset');
+        return this.jiraClient.makeRequest(options, callback, 'Columns Reset');
     };
 
     /**
@@ -139,7 +146,8 @@ function FilterClient(jiraClient) {
      * @method getDefaultShareScore
      * @memberOf FilterClient#
      * @param opts Ignored.
-     * @param callback Called when the default share scope has been retrieved.
+     * @param [callback] Called when the default share scope has been retrieved.
+     * @return {Promise} Resolved when the default share scope has been retrieved.
      */
     this.getDefaultShareScore = function (opts, callback) {
         var options = {
@@ -149,7 +157,7 @@ function FilterClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -159,7 +167,8 @@ function FilterClient(jiraClient) {
      * @memberOf FilterClient#
      * @param {Object} opts The request options sent to jira
      * @param {string} opts.scope The new default share scope. Available values are GLOBAL and PRIVATE.
-     * @param callback Called when the default share scope has been set.
+     * @param [callback] Called when the default share scope has been set.
+     * @return {Promise} Resolved when the default share scope has been set.
      */
     this.setDefaultShareScope = function (opts, callback) {
         var options = {
@@ -171,7 +180,7 @@ function FilterClient(jiraClient) {
                 scope: opts.scope
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -180,7 +189,8 @@ function FilterClient(jiraClient) {
      * @method getFavouriteFilters
      * @memberOf FilterClient#
      * @param opts Ignored.
-     * @param callback Called when the list of favourites has been retrieved.
+     * @param [callback] Called when the list of favourites has been retrieved.
+     * @return {Promise} Resolved when the list of favourites has been retrieved.
      */
     this.getFavoriteFilters = function (opts, callback) {
         var options = {
@@ -189,7 +199,7 @@ function FilterClient(jiraClient) {
             json: true,
             followAllRedirects: true
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**

--- a/api/group.js
+++ b/api/group.js
@@ -20,7 +20,8 @@ function GroupClient(jiraClient) {
      * @memberOf GroupClient#
      * @param opts The request options sent to jira
      * @param opts.group The group to create.  See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2011}
-     * @param callback Called when the group is created
+     * @param [callback] Called when the group is created
+     * @return {Promise} Resolved when the group is created
      */
     this.createGroup = function (opts, callback) {
         var options = {
@@ -31,7 +32,7 @@ function GroupClient(jiraClient) {
             body: opts.group
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -45,7 +46,8 @@ function GroupClient(jiraClient) {
      * @param opts The request options sent to the Jira API
      * @param opts.groupName A name of requested group.
      * @param opts.expand Array of fields to expand. Currently only available expand is "users".
-     * @param callback Called when the group is retrieved.
+     * @param [callback] Called when the group is retrieved.
+     * @return {Promise} Resolved when the group is retrieved.
      */
     this.getGroup = function (opts, callback) {
         var qs = {
@@ -67,7 +69,7 @@ function GroupClient(jiraClient) {
             qs: qs
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -78,7 +80,8 @@ function GroupClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.groupName A name of requested group.
      * @param {string} opts.userName The name of the user to add to the group.
-     * @param callback Called when the user has been added to the group.
+     * @param [callback] Called when the user has been added to the group.
+     * @return {Promise} Resolved when the user has been added to the group.
      */
     this.addUserToGroup = function (opts, callback) {
         var options = {
@@ -94,7 +97,7 @@ function GroupClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -105,7 +108,8 @@ function GroupClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.groupName A name of requested group.
      * @param {string} opts.userName The name of the user to add to the group.
-     * @param callback Called when the user has been added to the group.
+     * @param [callback] Called when the user has been added to the group.
+     * @return {Promise} Resolved when the user has been added to the group.
      */
     this.removeUserFromGroup = function (opts, callback) {
         var options = {
@@ -119,7 +123,7 @@ function GroupClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback, 'User Removed from Group');
+        return this.jiraClient.makeRequest(options, callback, 'User Removed from Group');
     };
 
     /**
@@ -130,7 +134,8 @@ function GroupClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.groupName A group to delete.
      * @param {string} [opts.swapGroup] A group to transfer visibility restrictions of the group that is being deleted
-     * @param callback Called when the group has been deleted.
+     * @param [callback] Called when the group has been deleted.
+     * @return {Promise} Resolved when the group has been deleted.
      */
     this.deleteGroup = function (opts, callback) {
         var options = {
@@ -144,6 +149,6 @@ function GroupClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback, 'Group Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Group Deleted');
     };
 }

--- a/api/groupUserPicker.js
+++ b/api/groupUserPicker.js
@@ -31,7 +31,8 @@ function GroupUserPickerClient(jiraClient) {
      *     occur multiple times to pass in multiple issue type ids. Comma separated value is not supported. Special
      *     values such as -1 (all standard issue types), -2 (all subtask issue types) are supported. This parameter is
      *     only used when fieldId is present.
-     * @param callback Called when the search is completed.
+     * @param [callback] Called when the search is completed.
+     * @return {Promise} Resolved when the search is completed.
      */
     this.findUsersAndGroups = function (opts, callback) {
         var options = {
@@ -49,6 +50,6 @@ function GroupUserPickerClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/groups.js
+++ b/api/groups.js
@@ -24,7 +24,8 @@ function GroupsClient(jiraClient) {
      * @param {string} opts.query A string against which to match groups.  Leave this blank to return all groups.
      * @param {string} opts.exclude A string specifying groups to exclude.
      * @param {number} opts.maxResults The maximum number of results to return.
-     * @param callback Called when the groups have been retrieved.
+     * @param [callback] Called when the groups have been retrieved.
+     * @return {Promise} Resolved when the groups have been retrieved.
      */
     this.findGroups = function (opts, callback) {
         var options = {
@@ -39,6 +40,6 @@ function GroupsClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/issue.js
+++ b/api/issue.js
@@ -27,7 +27,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueKey] The Key of teh issue.  EX: JWR-3
      * @param {string} [opts.boardId] The id of the board required to
      *        determine which field is used for estimation.
-     * @param callback
+     * @param [callback] Called when the issue estimation has been retrieved.
+     * @return {Promise} Resolved when the issue estimation has been retrieved.
      */
     this.getIssueEstimation = function (opts, callback) {
         var endpoint = '/issue/' + (opts.issueId || opts.issueKey) + '/estimation';
@@ -44,7 +45,7 @@ function IssueClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -61,7 +62,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueKey] The Key of teh issue.  EX: JWR-3
      * @param {string} [opts.boardId] The id of the board required to
      *        determine which field is used for estimation.
-     * @param callback
+     * @param [callback] Called when the issue estimation has been created.
+     * @return {Promise} Resolved when the issue estimation has been created.
      */
     this.setIssueEstimation = function (opts, callback) {
         var endpoint = '/issue/' + (opts.issueId || opts.issueKey) + '/estimation';
@@ -81,7 +83,7 @@ function IssueClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -91,7 +93,8 @@ function IssueClient(jiraClient) {
      * @memberOf IssueClient#
      * @param {Object} ranking The ranking data in the form of PUT body to the
      *        Jira API.
-     * @param callback
+     * @param [callback] Called when the issue rank has been created.
+     * @return {Promise} Resolved when the issue rank has been created.
      */
     this.setIssueRanks = function (ranking, callback) {
         var options = {
@@ -102,7 +105,7 @@ function IssueClient(jiraClient) {
             body: ranking
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -122,7 +125,8 @@ function IssueClient(jiraClient) {
      * @memberof IssueClient#
      * @param {Object} issue The issue data in the form of POST body to the JIRA API.
      * See {@link https://docs.atlassian.com/jira/REST/latest/#d2e398}
-     * @param callback Called when the issue has been created.
+     * @param [callback] Called when the issue has been created.
+     * @return {Promise} Resolved when the issue has been created.
      */
     this.createIssue = function (issue, callback) {
         var options = {
@@ -133,7 +137,7 @@ function IssueClient(jiraClient) {
             body: issue
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -166,7 +170,8 @@ function IssueClient(jiraClient) {
      *     the results. If null, all issue types are returned. This parameter can be specified multiple times, but is
      *     NOT interpreted as a comma-separated list. Specifiying an issue type that does not exist is not an error.
      * @param {string} [opts.expand] in order to get expanded field descriptions, specify 'projects.issuetypes.fields' here.
-     * @param callback Called when the metadata has been retrieved.
+     * @param [callback] Called when the metadata has been retrieved.
+     * @return {Promise} Resolved when the metadata has been retrieved.
      */
     this.getCreateMetadata = function (opts, callback) {
         var options = {
@@ -183,7 +188,7 @@ function IssueClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -197,7 +202,8 @@ function IssueClient(jiraClient) {
      * @method bulkCreate
      * @memberof IssueClient#
      * @param issues See {@link https://docs.atlassian.com/jira/REST/latest/#d2e828}
-     * @param callback Called when the issues have been created.
+     * @param [callback] Called when the issues have been created.
+     * @return {Promise} Resolved when the issues have been created.
      */
     this.bulkCreate = function (issues, callback) {
         var options = {
@@ -208,7 +214,7 @@ function IssueClient(jiraClient) {
             body: issues
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -247,7 +253,8 @@ function IssueClient(jiraClient) {
      * @param {Object} [opts.fields] See {@link https://docs.atlassian.com/jira/REST/latest/#d2e611}
      * @param {Object} [opts.expand] See {@link https://docs.atlassian.com/jira/REST/latest/#d2e611}
      * @param {Object} [opts.properties] See {@link https://docs.atlassian.com/jira/REST/latest/#d2e611}
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.getIssue = function (opts, callback) {
         if (!opts.agile) {
@@ -268,7 +275,7 @@ function IssueClient(jiraClient) {
             };
         }
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -284,12 +291,13 @@ function IssueClient(jiraClient) {
      * @param {boolean} [opts.deleteSubTasks] "a String of true or false indicating that any subtasks should also
      *        be deleted. If the issue has no subtasks this parameter is ignored. If the issue has subtasks and this
      *        parameter is missing or false, then the issue will not be deleted and an error will be returned."
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.deleteIssue = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'DELETE', null, {deleteSubTasks: opts.deleteSubTasks});
 
-        this.jiraClient.makeRequest(options, callback, 'Issue Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Issue Deleted');
     };
 
     /**
@@ -312,7 +320,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {Object} opts.issue See {@link https://docs.atlassian.com/jira/REST/latest/#d2e656}
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.editIssue = function (opts, callback) {
         if (!opts.issue) {
@@ -320,7 +329,7 @@ function IssueClient(jiraClient) {
         }
         var options = this.buildRequestOptions(opts, '', 'PUT', opts.issue, opts.qs);
 
-        this.jiraClient.makeRequest(options, callback, 'Issue Updated');
+        return this.jiraClient.makeRequest(options, callback, 'Issue Updated');
     };
 
     /**
@@ -336,16 +345,17 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.assignee The name of the user to whom to assign the issue. -1 for default, null for no
      *     assignee.
-     * @param callback Called when the issue has been assigned.
+     * @param [callback] Called when the issue has been assigned.
+     * @return {Promise} Resolved when the issue has been assigned.
      */
     this.assignIssue = function (opts, callback) {
-        if (typeof opts.assignee === "string" && opts.assignee.length || opts.assignee === null) {
-            var options = this.buildRequestOptions(opts, '/assignee', 'PUT', {name: opts.assignee});
-
-            this.jiraClient.makeRequest(options, callback, 'Issue Assigned');
-        } else {
+        if (!(typeof opts.assignee === "string" && opts.assignee.length || opts.assignee === null)) {
             throw new Error(errorStrings.NO_ASSIGNEE_ERROR);
         }
+
+        var options = this.buildRequestOptions(opts, '/assignee', 'PUT', {name: opts.assignee});
+
+        return this.jiraClient.makeRequest(options, callback, 'Issue Assigned');
     };
 
     /**
@@ -358,12 +368,13 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {Object} opts.expand See {@link https://docs.atlassian.com/jira/REST/latest/#d2e461}
-     * @param callback Called when the issue has been assigned.
+     * @param [callback] Called when the issue has been assigned.
+     * @return {Promise} Resolved when the issue has been assigned.
      */
     this.getComments = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/comment', 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -376,7 +387,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {Object} opts.comment See {@link https://docs.atlassian.com/jira/REST/latest/#d2e482}
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.addComment = function (opts, callback) {
         var options;
@@ -386,7 +398,7 @@ function IssueClient(jiraClient) {
             options = this.buildRequestOptions(opts, '/comment', 'POST', {body: opts.comment});
         }
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -399,7 +411,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.commentId The id of the comment.
-     * @param callback Called when the comment is retrieved.
+     * @param [callback] Called when the comment is retrieved.
+     * @return {Promise} Resolved when the comment is retrieved.
      */
     this.getComment = function (opts, callback) {
         if (!opts.commentId) {
@@ -407,7 +420,7 @@ function IssueClient(jiraClient) {
         }
         var options = this.buildRequestOptions(opts, '/comment/' + opts.commentId, 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -421,7 +434,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.commentId The id of the comment.
      * @param {Object} opts.comment See {@link https://docs.atlassian.com/jira/REST/latest/#d2e539}
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.editComment = function (opts, callback) {
         if (!opts.comment) {
@@ -431,7 +445,7 @@ function IssueClient(jiraClient) {
         }
         var options = this.buildRequestOptions(opts, '/comment/' + opts.commentId, 'PUT', opts.comment);
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -444,7 +458,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.commentId The id of the comment.
-     * @param callback Called when the comment is retrieved.
+     * @param [callback] Called when the comment is retrieved.
+     * @return {Promise} Resolved when the comment is retrieved.
      */
     this.deleteComment = function (opts, callback) {
         if (!opts.commentId) {
@@ -452,7 +467,7 @@ function IssueClient(jiraClient) {
         }
         var options = this.buildRequestOptions(opts, '/comment/' + opts.commentId, 'DELETE');
 
-        this.jiraClient.makeRequest(options, callback, 'Comment Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Comment Deleted');
     };
 
     /**
@@ -467,12 +482,13 @@ function IssueClient(jiraClient) {
      *        issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
-     * @param callback Called when the metadata is retrieved.
+     * @param [callback] Called when the metadata is retrieved.
+     * @return {Promise} Resolved when the metadata is retrieved.
      */
     this.getEditMetadata = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/editmeta', 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -487,7 +503,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {Object} opts.notification See {@link https://docs.atlassian.com/jira/REST/latest/#d2e435}
-     * @param callback Called when the metadata is retrieved.
+     * @param [callback] Called when the metadata is retrieved.
+     * @return {Promise} Resolved when the metadata is retrieved.
      */
     this.sendEmailNotification = function (opts, callback) {
         if (!opts.notification) {
@@ -496,7 +513,7 @@ function IssueClient(jiraClient) {
 
         var options = this.buildRequestOptions(opts, '/notify', 'POST', opts.notification);
 
-        this.jiraClient.makeRequest(options, callback, 'Notifications Sent');
+        return this.jiraClient.makeRequest(options, callback, 'Notifications Sent');
     };
 
     /**
@@ -511,12 +528,13 @@ function IssueClient(jiraClient) {
      * @param {string} opts.globalId The id of the remote issue link to be returned. If null (not provided) all remote
      *     links for the issue are returned. For a full explanation of Issue Link fields please refer to
      *     {@link https://developer.atlassian.com/display/JIRADEV/Fields+in+Remote+Issue+Links}
-     * @param callback Called when the remote links are retrieved.
+     * @param [callback] Called when the remote links are retrieved.
+     * @return {Promise} Resolved when the remote links are retrieved.
      */
     this.getRemoteLinks = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/remotelink', 'GET', null, {globalId: opts.globalId});
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -530,12 +548,13 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {Object} opts.remoteLink See {@link https://docs.atlassian.com/jira/REST/latest/#d2e945}
-     * @param callback Called when the remote links are retrieved.
+     * @param [callback] Called when the remote links are retrieved.
+     * @return {Promise} Resolved when the remote links are retrieved.
      */
     this.createRemoteLink = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/remotelink', 'POST', opts.remoteLink);
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -549,7 +568,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {Object} opts.remoteLink See {@link https://docs.atlassian.com/jira/REST/latest/#d2e945}
-     * @param callback Called when the remote links are retrieved.
+     * @param [callback] Called when the remote links are retrieved.
+     * @return {Promise} Resolved when the remote links are retrieved.
      */
     this.updateRemoteLink = function (opts, callback) {
         // The one API endpoint handles both updates and creation.
@@ -566,7 +586,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.globalId The global id of the remote issue link
-     * @param callback Called when the remote links are retrieved.
+     * @param [callback] Called when the remote links are retrieved.
+     * @return {Promise} Resolved when the remote links are retrieved.
      */
     this.deleteRemoteLink = function (opts, callback) {
         if (!opts.globalId) {
@@ -575,7 +596,7 @@ function IssueClient(jiraClient) {
 
         var options = this.buildRequestOptions(opts, '/remotelink', 'DELETE', null, {globalId: opts.globalId});
 
-        this.jiraClient.makeRequest(options, callback, 'RemoteLink Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'RemoteLink Deleted');
     };
 
     /**
@@ -588,7 +609,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.linkId The id of the remote link
-     * @param callback Called when the remote links are retrieved.
+     * @param [callback] Called when the remote links are retrieved.
+     * @return {Promise} Resolved when the remote links are retrieved.
      */
     this.getRemoteLinkById = function (opts, callback) {
         if (!opts.linkId) {
@@ -597,7 +619,7 @@ function IssueClient(jiraClient) {
 
         var options = this.buildRequestOptions(opts, '/remotelink/' + opts.linkId, 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -611,7 +633,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.linkId The id of the remote link
      * @param {string} opts.remoteLink See {@link https://docs.atlassian.com/jira/REST/latest/#d2e1037}
-     * @param callback Called when the remote links are retrieved.
+     * @param [callback] Called when the remote links are retrieved.
+     * @return {Promise} Resolved when the remote links are retrieved.
      */
     this.updateRemoteLinkById = function (opts, callback) {
         if (!opts.linkId) {
@@ -620,7 +643,7 @@ function IssueClient(jiraClient) {
 
         var options = this.buildRequestOptions(opts, '/remotelink/' + opts.linkId, 'PUT', opts.remoteLink);
 
-        this.jiraClient.makeRequest(options, callback, 'RemoteLink Updated');
+        return this.jiraClient.makeRequest(options, callback, 'RemoteLink Updated');
     };
 
     /**
@@ -633,7 +656,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.linkId The id of the remote link
-     * @param callback Called when the remote links are retrieved.
+     * @param [callback] Called when the remote links are retrieved.
+     * @return {Promise} Resolved when the remote links are retrieved.
      */
     this.deleteRemoteLinkById = function (opts, callback) {
         if (!opts.linkId) {
@@ -642,7 +666,7 @@ function IssueClient(jiraClient) {
 
         var options = this.buildRequestOptions(opts, '/remotelink/' + opts.linkId, 'DELETE');
 
-        this.jiraClient.makeRequest(options, callback, 'RemoteLink Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'RemoteLink Deleted');
     };
 
     /**
@@ -661,12 +685,13 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.transitionId If specified, will call back with only the transition with the specified id.
-     * @param callback Called when the transitions are retrieved.
+     * @param [callback] Called when the transitions are retrieved.
+     * @return {Promise} Resolved when the transitions are retrieved.
      */
     this.getTransitions = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/transitions', 'GET', null, {transitionId: opts.transitionId});
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -684,7 +709,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.transition See {@link https://docs.atlassian.com/jira/REST/latest/#d2e698}
-     * @param callback Called when the transitions are retrieved.
+     * @param [callback] Called when the transitions are retrieved.
+     * @return {Promise} Resolved when the transitions are retrieved.
      */
     this.transitionIssue = function (opts, callback) {
         if (!opts.transition) {
@@ -697,7 +723,7 @@ function IssueClient(jiraClient) {
         } else {
             options = this.buildRequestOptions(opts, '/transitions', 'POST', opts.transition)
         }
-        this.jiraClient.makeRequest(options, callback, 'Issue Transitioned');
+        return this.jiraClient.makeRequest(options, callback, 'Issue Transitioned');
     };
 
     /**
@@ -709,12 +735,13 @@ function IssueClient(jiraClient) {
      *     issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
-     * @param callback Called after the vote is removed.
+     * @param [callback] Called after the vote is removed.
+     * @return {Promise} Resolved after the vote is removed.
      */
     this.unvote = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/votes', 'DELETE');
 
-        this.jiraClient.makeRequest(options, callback, 'Vote Removed');
+        return this.jiraClient.makeRequest(options, callback, 'Vote Removed');
     };
 
     /**
@@ -726,12 +753,13 @@ function IssueClient(jiraClient) {
      *     issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
-     * @param callback Called after the vote is removed.
+     * @param [callback] Called after the vote is removed.
+     * @return {Promise} Resolved after the vote is removed.
      */
     this.vote = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/votes', 'POST');
 
-        this.jiraClient.makeRequest(options, callback, 'Vote Added');
+        return this.jiraClient.makeRequest(options, callback, 'Vote Added');
     };
 
     /**
@@ -743,12 +771,13 @@ function IssueClient(jiraClient) {
      *     issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
-     * @param callback Called after the votes are retrieved.
+     * @param [callback] Called after the votes are retrieved.
+     * @return {Promise} Resolved after the votes are retrieved.
      */
     this.getVotes = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/votes', 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -760,12 +789,13 @@ function IssueClient(jiraClient) {
      *     issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
-     * @param callback Called after the watchers are retrieved.
+     * @param [callback] Called after the watchers are retrieved.
+     * @return {Promise} Resolved after the watchers are retrieved.
      */
     this.getWatchers = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/watchers', 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -778,7 +808,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.watcher The username of the user to add as a watcher.
-     * @param callback Called after the watcher is added.
+     * @param [callback] Called after the watcher is added.
+     * @return {Promise} Resolved after the watcher is added.
      */
     this.addWatcher = function (opts, callback) {
         if (!opts.watcher) {
@@ -786,7 +817,7 @@ function IssueClient(jiraClient) {
         }
         var options = this.buildRequestOptions(opts, '/watchers', 'POST', opts.watcher);
 
-        this.jiraClient.makeRequest(options, callback, 'Watcher Added');
+        return this.jiraClient.makeRequest(options, callback, 'Watcher Added');
     };
 
     /**
@@ -799,7 +830,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.watcher The username of the user to remove as a watcher.
-     * @param callback Called after the watcher is removed.
+     * @param [callback] Called after the watcher is removed.
+     * @return {Promise} Resolved after the watcher is removed.
      */
     this.removeWatcher = function (opts, callback) {
         if (!opts.watcher) {
@@ -807,7 +839,7 @@ function IssueClient(jiraClient) {
         }
         var options = this.buildRequestOptions(opts, '/watchers', 'DELETE', null, {username: opts.watcher});
 
-        this.jiraClient.makeRequest(options, callback, 'Watcher Removed');
+        return this.jiraClient.makeRequest(options, callback, 'Watcher Removed');
     };
 
     /**
@@ -819,12 +851,13 @@ function IssueClient(jiraClient) {
      *     issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
-     * @param callback Called after the worklogs are retrieved.
+     * @param [callback] Called after the worklogs are retrieved.
+     * @return {Promise} Resolved after the worklogs are retrieved.
      */
     this.getWorkLogs = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/worklog', 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -848,7 +881,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.reduceBy] (required when "manual" is selected for adjustEstimate) the amount to reduce the
      *     remaining estimate by e.g. "2d"
      * @param {Object} opts.worklog See {@link: https://docs.atlassian.com/jira/REST/latest/#d2e1106}
-     * @param callback Called after the worklog is added.
+     * @param [callback] Called after the worklog is added.
+     * @return {Promise} Resolved after the worklog is added.
      */
     this.addWorkLog = function (opts, callback) {
         if (!opts.worklog) {
@@ -860,7 +894,7 @@ function IssueClient(jiraClient) {
             adjustEstimate: opts.adjustEstimate
         });
 
-        this.jiraClient.makeRequest(options, callback, 'Worklog Added');
+        return this.jiraClient.makeRequest(options, callback, 'Worklog Added');
     };
 
     /**
@@ -873,7 +907,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.worklogId The id of the work log to retrieve.
-     * @param callback Called after the worklog is retrieved.
+     * @param [callback] Called after the worklog is retrieved.
+     * @return {Promise} Resolved after the worklog is retrieved.
      */
     this.getWorkLog = function (opts, callback) {
         if (!opts.worklogId) {
@@ -881,7 +916,7 @@ function IssueClient(jiraClient) {
         }
         var options = this.buildRequestOptions(opts, '/worklog/' + opts.worklogId, 'GET');
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -903,7 +938,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.newEstimate] (required when "new" is selected for adjustEstimate) the new value for the
      *     remaining estimate field. e.g. "2d"
      * @param {Object} opts.worklog See {@link: https://docs.atlassian.com/jira/REST/latest/#d2e1161}
-     * @param callback Called after the worklog is updated.
+     * @param [callback] Called after the worklog is updated.
+     * @return {Promise} Resolved after the worklog is updated.
      */
     this.updateWorkLog = function (opts, callback) {
         if (!opts.worklogId) {
@@ -917,7 +953,7 @@ function IssueClient(jiraClient) {
             adjustEstimate: opts.adjustEstimate
         });
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -941,7 +977,8 @@ function IssueClient(jiraClient) {
      *     remaining estimate field. e.g. "2d"
      * @param {string} [opts.increaseBy] (required when "manual" is selected for adjustEstimate) the amount to reduce
      *     the remaining estimate by e.g. "2d"
-     * @param callback Called after the work log is deleted.
+     * @param [callback] Called after the work log is deleted.
+     * @return {Promise} Resolved after the work log is deleted.
      */
     this.deleteWorkLog = function (opts, callback) {
         if (!opts.worklogId) {
@@ -952,20 +989,21 @@ function IssueClient(jiraClient) {
             increaseBy: opts.increaseBy,
             adjustEstimate: opts.adjustEstimate
         });
-        this.jiraClient.makeRequest(options, callback, 'Work Log Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Work Log Deleted');
     };
 
     /**
      * Add an attachments to an issue.
      *
      * @method addAttachment
-     * @memberOf IssueClient.js
+     * @memberOf IssueClient
      * @param {Object} opts The options to pass to the API.  Note that this object must contain EITHER an issueId or
      *     issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.filename The file name of attachment. If you pass an array of filenames, multiple attachments will be added.
-     * @param callback Called when the attachment has been attached.
+     * @param [callback] Called when the attachment has been attached.
+     * @return {Promise} Resolved when the attachment has been attached.
      */
     this.addAttachment = function (opts, callback) {
         if (!opts.filename) {
@@ -980,7 +1018,7 @@ function IssueClient(jiraClient) {
             "X-Atlassian-Token": "nocheck"
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -993,11 +1031,12 @@ function IssueClient(jiraClient) {
      *     issueKey property; issueId will be used over issueKey if both are present.
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
-     * @param callback Called when the properties are retrieved.
+     * @param [callback] Called when the properties are retrieved.
+     * @return {Promise} Resolved when the properties are retrieved.
      */
     this.getProperties = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/properties', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -1015,7 +1054,8 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.propertyKey The key of the property being set.
      * @param {Object} opts.propertyValue The value of the property being set.
-     * @param callback Called when the property is set.
+     * @param [callback] Called when the property is set.
+     * @return {Promise} Resolved when the property is set.
      */
     this.setProperty = function (opts, callback) {
         if (!opts.propertyKey) {
@@ -1024,7 +1064,7 @@ function IssueClient(jiraClient) {
             throw new Error(errorStrings.NO_PROPERTY_VALUE_ERROR);
         }
         var options = this.buildRequestOptions(opts, '/properties/' + opts.propertyKey, 'PUT', opts.propertyValue);
-        this.jiraClient.makeRequest(options, callback, 'Property Set');
+        return this.jiraClient.makeRequest(options, callback, 'Property Set');
     };
 
     /**
@@ -1040,14 +1080,15 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.propertyKey The key of the property being set.
-     * @param callback Called when the property is retrieved.
+     * @param [callback] Called when the property is retrieved.
+     * @return {Promise} Resolved when the property is retrieved.
      */
     this.getProperty = function (opts, callback) {
         if (!opts.propertyKey) {
             throw new Error(errorStrings.NO_PROPERTY_KEY_ERROR);
         }
         var options = this.buildRequestOptions(opts, '/properties/' + opts.propertyKey, 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -1063,14 +1104,15 @@ function IssueClient(jiraClient) {
      * @param {string} [opts.issueId] The id of the issue.  EX: 10002
      * @param {string} [opts.issueKey] The Key of the issue.  EX: JWR-3
      * @param {string} opts.propertyKey The key of the property being set.
-     * @param callback Called when the property is deleted.
+     * @param [callback] Called when the property is deleted.
+     * @return {Promise} Resolved when the property is deleted.
      */
     this.deleteProperty = function (opts, callback) {
         if (!opts.propertyKey) {
             throw new Error(errorStrings.NO_PROPERTY_KEY_ERROR);
         }
         var options = this.buildRequestOptions(opts, '/properties/' + opts.propertyKey, 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Property Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Property Deleted');
     };
 
     /**
@@ -1107,7 +1149,7 @@ function IssueClient(jiraClient) {
                 qs.expand += ex + ','
             });
         }
-        
+
         if (opts.properties) {
             qs.properties = '';
             opts.properties.forEach(function (prop) {

--- a/api/issueLink.js
+++ b/api/issueLink.js
@@ -26,7 +26,8 @@ function IssueLinkClient(jiraClient) {
      * @method createIssueLink
      * @param opts The options for the request sent to the Jira API
      * @param opts.issueLink See {@link https://docs.atlassian.com/jira/REST/latest/#d2e5010}
-     * @param callback Called when the link has been created.
+     * @param [callback] Called when the link has been created.
+     * @return {Promise} Resolved when the link has been created.
      */
     this.createIssueLink = function (opts, callback) {
         if (!opts.issueLink) {
@@ -41,7 +42,7 @@ function IssueLinkClient(jiraClient) {
             body: opts.issueLink
         };
 
-        this.jiraClient.makeRequest(options, callback, 'Issue Link Created');
+        return this.jiraClient.makeRequest(options, callback, 'Issue Link Created');
     };
 
     /**
@@ -51,7 +52,8 @@ function IssueLinkClient(jiraClient) {
      * @memberOf IssueLinkClient#
      * @param opts The options used in the request to the Jira API
      * @param opts.linkId The id of the link to retrieve.
-     * @param callback Called when the Issue Link has been retrieved.
+     * @param [callback] Called when the Issue Link has been retrieved.
+     * @return {Promise} Resolved when the Issue Link has been retrieved.
      */
     this.getIssueLink = function (opts, callback) {
         if (!opts.linkId) {
@@ -65,7 +67,7 @@ function IssueLinkClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -76,7 +78,8 @@ function IssueLinkClient(jiraClient) {
      * @memberOf IssueLinkClient#
      * @param opts The options used in the request to the Jira API
      * @param opts.linkId The id of the link to delete.
-     * @param callback Called when the Issue Link has been deleted.
+     * @param [callback] Called when the Issue Link has been deleted.
+     * @return {Promise} Resolved when the Issue Link has been deleted.
      */
     this.deleteIssueLink = function (opts, callback) {
         if (!opts.linkId) {
@@ -90,6 +93,6 @@ function IssueLinkClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback, 'Issue Link Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Issue Link Deleted');
     };
 }

--- a/api/issueLinkType.js
+++ b/api/issueLinkType.js
@@ -19,7 +19,8 @@ function IssueLinkTypeClient(jiraClient) {
      * @method getAvailableTypes
      * @memberOf IssueLinkTypeClient#
      * @param opts The request options for the API.  Ignored in this function.
-     * @param callback Called when the available IssueLink types are retrieved.
+     * @param [callback] Called when the available IssueLink types are retrieved.
+     * @return {Promise} Resolved when the available IssueLink types are retrieved.
      */
     this.getAvailableTypes = function (opts, callback) {
         var options = {
@@ -29,7 +30,7 @@ function IssueLinkTypeClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -39,7 +40,8 @@ function IssueLinkTypeClient(jiraClient) {
      * @memberOf IssueLinkTypeClient#
      * @param opts The request options sent to the Jira API
      * @param opts.linkType See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2018}
-     * @param callback Called when the IssueLink type has been created.
+     * @param [callback] Called when the IssueLink type has been created.
+     * @return {Promise} Resolved when the IssueLink type has been created.
      */
     this.createIssueLinkType = function (opts, callback) {
         var options = {
@@ -50,7 +52,7 @@ function IssueLinkTypeClient(jiraClient) {
             body: opts.linkType
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -60,7 +62,8 @@ function IssueLinkTypeClient(jiraClient) {
      * @memberOf IssueLinkTypeClient#
      * @param opts The request options sent to the Jira API
      * @param opts.issueLinkTypeId The id of the IssueLink type to retrieve.
-     * @param callback Called when the IssueLink type has been retrieved
+     * @param [callback] Called when the IssueLink type has been retrieved
+     * @return {Promise} Resolved when the IssueLink type has been retrieved
      */
     this.getIssueLinkType = function (opts, callback) {
         if (!opts.issueLinkTypeId) {
@@ -74,7 +77,7 @@ function IssueLinkTypeClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -84,7 +87,8 @@ function IssueLinkTypeClient(jiraClient) {
      * @memberOf IssueLinkTypeClient#
      * @param opts The request options sent to the Jira API
      * @param opts.issueLinkTypeId The id of the IssueLink type to delete.
-     * @param callback Called when the IssueLink type has been delete
+     * @param [callback] Called when the IssueLink type has been delete
+     * @return {Promise} Resolved when the IssueLink type has been delete
      */
     this.deleteIssueLinkType = function (opts, callback) {
         if (!opts.issueLinkTypeId) {
@@ -98,7 +102,7 @@ function IssueLinkTypeClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback, 'IssueLink type deleted.');
+        return this.jiraClient.makeRequest(options, callback, 'IssueLink type deleted.');
     };
 
     /**
@@ -109,7 +113,8 @@ function IssueLinkTypeClient(jiraClient) {
      * @param opts The request options sent to the Jira API
      * @param opts.issueLinkTypeId The id of the IssueLink type to retrieve.
      * @param opts.linkType See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2071}
-     * @param callback Called when the IssueLink type has been updated.
+     * @param [callback] Called when the IssueLink type has been updated.
+     * @return {Promise} Resolved when the IssueLink type has been updated.
      */
     this.editIssueLinkType = function (opts, callback) {
         if (!opts.issueLinkTypeId) {
@@ -124,6 +129,6 @@ function IssueLinkTypeClient(jiraClient) {
             body: opts.issueLinkType
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/issueType.js
+++ b/api/issueType.js
@@ -17,7 +17,8 @@ function IssueTypeClient(jiraClient) {
      * @method getAllIssueTypes
      * @memberOf IssueTypeClient#
      * @param opts Ignored
-     * @param callback Called when the issue types have been retrieved.
+     * @param [callback] Called when the issue types have been retrieved.
+     * @return {Promise} Resolved when the issue types have been retrieved.
      */
     this.getAllIssueTypes = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function IssueTypeClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function IssueTypeClient(jiraClient) {
      * @memberOf IssueTypeClient#
      * @param opts The options sent to the Jira API
      * @param opts.issueTypeId A String containing an issue type id
-     * @param callback Called when the issue type has been retrieved.
+     * @param [callback] Called when the issue type has been retrieved.
+     * @return {Promise} Resolved when the issue type has been retrieved.
      */
     this.getIssueType = function (opts, callback) {
         var options = {
@@ -47,6 +49,6 @@ function IssueTypeClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/jql.js
+++ b/api/jql.js
@@ -17,7 +17,8 @@ function JqlClient(jiraClient) {
      * @method getAutoCompleteData
      * @memberOf JqlClient#
      * @param opts The options sent to the Jira API.  Ignored by this function.
-     * @param callback Called when the autocomplete data is returned.
+     * @param [callback] Called when the autocomplete data is returned.
+     * @return {Promise} Resolved when the autocomplete data is returned.
      */
     this.getAutoCompleteData = function (opts, callback) {
         var options = {
@@ -27,6 +28,6 @@ function JqlClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback)
+        return this.jiraClient.makeRequest(options, callback)
     }
 }

--- a/api/licenseRole.js
+++ b/api/licenseRole.js
@@ -16,7 +16,8 @@ function LicenseRoleClient(jiraClient) {
      * @method getAllLicenseRoles
      * @memberOf LicenseRoleClient#
      * @param opts Ignored
-     * @param callback Called when the license roles have been retrieved.
+     * @param [callback] Called when the license roles have been retrieved.
+     * @return {Promise} Resolved when the license roles have been retrieved.
      */
     this.getAllLicenseRoles = function (opts, callback) {
         var options = {
@@ -26,7 +27,7 @@ function LicenseRoleClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -36,7 +37,8 @@ function LicenseRoleClient(jiraClient) {
      * @memberOf LicenseRoleClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.roleId The id of the license role to retrieve.
-     * @param callback Called when the license role is retrieved.
+     * @param [callback] Called when the license role is retrieved.
+     * @return {Promise} Resolved when the license role is retrieved.
      */
     this.getLicenseRole = function (opts, callback) {
         var options = {
@@ -46,7 +48,7 @@ function LicenseRoleClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -59,7 +61,8 @@ function LicenseRoleClient(jiraClient) {
      * @param opts.roleId The id of the license role to retrieve.
      * @param opts.role The new data to place in the role.  See
      *  {@link https://docs.atlassian.com/jira/REST/latest/#d2e365}
-     * @param callback Called when the license role is edited.
+     * @param [callback] Called when the license role is edited.
+     * @return {Promise} Resolved when the license role is edited.
      */
     this.editLicenseRole = function (opts, callback) {
         var options = {
@@ -70,6 +73,6 @@ function LicenseRoleClient(jiraClient) {
             body: opts.role
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/licenseValidator.js
+++ b/api/licenseValidator.js
@@ -17,7 +17,8 @@ function LicenseValidatorClient(jiraClient) {
      * @memberOf LicenseValidatorClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.license The license to validate.
-     * @param callback Called when the license has been validated, or fails to validate.
+     * @param [callback] Called when the license has been validated, or fails to validate.
+     * @return {Promise} Resolved when the license has been validated, or fails to validate.
      */
     this.validateLicense = function (opts, callback) {
         var options = {
@@ -28,6 +29,6 @@ function LicenseValidatorClient(jiraClient) {
             body: opts.license
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/myPermissions.js
+++ b/api/myPermissions.js
@@ -33,7 +33,8 @@ function MyPermissionsClient(jiraClient) {
      * @method getMyPermissions
      * @memberOf MyPermissionsClient#
      * @param opts The request options sent to the Jira API
-     * @param callback Called when the permissions have been returned.
+     * @param [callback] Called when the permissions have been returned.
+     * @return {Promise} Resolved when the permissions have been returned.
      */
     this.getMyPermissions = function (opts, callback) {
         var options = {
@@ -43,6 +44,6 @@ function MyPermissionsClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/myPreferences.js
+++ b/api/myPreferences.js
@@ -19,7 +19,8 @@ function MyPreferencesClient(jiraClient) {
      * @memberOf MyPreferencesClient#
      * @param opts The request options send to the Jira API.
      * @param opts.key Key of the preference to be returned.
-     * @param callback Called when the preference has been retrieved.
+     * @param [callback] Called when the preference has been retrieved.
+     * @return {Promise} Resolved when the preference has been retrieved.
      */
     this.getPreference = function (opts, callback) {
         var options = {
@@ -32,7 +33,7 @@ function MyPreferencesClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -43,7 +44,8 @@ function MyPreferencesClient(jiraClient) {
      * @param opts The request options send to the Jira API.
      * @param opts.key Key of the preference to be edited.
      * @param opts.value The new value to set for the preference.
-     * @param callback Called when the preference has been edited.
+     * @param [callback] Called when the preference has been edited.
+     * @return {Promise} Resolved when the preference has been edited.
      */
     this.editPreference = function (opts, callback) {
         var options = {
@@ -57,7 +59,7 @@ function MyPreferencesClient(jiraClient) {
             body: opts.value
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -67,7 +69,8 @@ function MyPreferencesClient(jiraClient) {
      * @memberOf MyPreferencesClient#
      * @param opts The request options send to the Jira API.
      * @param opts.key Key of the preference to be deleted.
-     * @param callback Called when the preference has been deleted.
+     * @param [callback] Called when the preference has been deleted.
+     * @return {Promise} Resolved when the preference has been deleted.
      */
     this.deletePreference = function (opts, callback) {
         var options = {
@@ -80,6 +83,6 @@ function MyPreferencesClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/myself.js
+++ b/api/myself.js
@@ -17,7 +17,8 @@ function MyselfClient(jiraClient) {
      * @method getMyself
      * @memberOf MyselfClient#
      * @param opts Ignored
-     * @param callback Called when the current user is retrieved.
+     * @param [callback] Called when the current user is retrieved.
+     * @return {Promise} Resolved when the current user is retrieved.
      */
     this.getMyself = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function MyselfClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -38,7 +39,8 @@ function MyselfClient(jiraClient) {
      * @memberOf MyselfClient#
      * @param opts The request options send to the Jira API.
      * @param opts.newData The new data.  See {@link https://docs.atlassian.com/jira/REST/latest/#d2e1242}
-     * @param callback Called when the user's data has been modified
+     * @param [callback] Called when the user's data has been modified
+     * @return {Promise} Resolved when the user's data has been modified
      */
     this.editMyself = function (opts, callback) {
         var options = {
@@ -49,7 +51,7 @@ function MyselfClient(jiraClient) {
             body: opts.newData
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -59,7 +61,8 @@ function MyselfClient(jiraClient) {
      * @memberOf MyselfClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.newData The new data
-     * @param callback Called when the password has been changed.
+     * @param [callback] Called when the password has been changed.
+     * @return {Promise} Resolved when the password has been changed.
      */
     this.changePassword = function (opts, callback) {
         var options = {
@@ -70,6 +73,6 @@ function MyselfClient(jiraClient) {
             body: opts.newData
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/password.js
+++ b/api/password.js
@@ -20,7 +20,8 @@ function PasswordClient(jiraClient) {
      * @param {boolean} [opts.hasOldPassword=false] Whether or not the user will be required to enter their current
      *     password. Use false (the default) if this is a new user or if an administrator is forcibly changing another
      *     user's password.
-     * @param callback Called when the password policy has been retrieved.
+     * @param [callback] Called when the password policy has been retrieved.
+     * @return {Promise} Resolved when the password policy has been retrieved.
      */
     this.getPasswordPolicy = function (opts, callback) {
         var options = {
@@ -33,6 +34,6 @@ function PasswordClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/priority.js
+++ b/api/priority.js
@@ -17,7 +17,8 @@ function PriorityClient(jiraClient) {
      * @method getAllPriorities
      * @memberOf PriorityClient#
      * @param opts Ignored
-     * @param callback Called when the priorities have been retrieved.
+     * @param [callback] Called when the priorities have been retrieved.
+     * @return {Promise} Resolved when the priorities have been retrieved.
      */
     this.getAllPriorities = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function PriorityClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function PriorityClient(jiraClient) {
      * @memberOf PriorityClient#
      * @param opts The options sent to the Jira API
      * @param opts.priorityId A String containing a priority id
-     * @param callback Called when the priority has been retrieved.
+     * @param [callback] Called when the priority has been retrieved.
+     * @return {Promise} Resolved when the priority has been retrieved.
      */
     this.getPriority = function (opts, callback) {
         var options = {
@@ -47,6 +49,6 @@ function PriorityClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/project.js
+++ b/api/project.js
@@ -17,7 +17,8 @@ function ProjectClient(jiraClient) {
      * @method getAllProjects
      * @memberOf ProjectClient#
      * @param opts Ignored
-     * @param callback Called when the projects have been retrieved.
+     * @param [callback] Called when the projects have been retrieved.
+     * @return {Promise} Resolved when the projects have been retrieved.
      */
     this.getAllProjects = function (opts, callback) {
         var options = {
@@ -26,7 +27,7 @@ function ProjectClient(jiraClient) {
             json: true,
             followAllRedirects: true
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -36,11 +37,12 @@ function ProjectClient(jiraClient) {
      * @memberOf ProjectClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.projectIdOrKey The project id or project key
-     * @param callback Called when the project has been deleted.
+     * @param [callback] Called when the project has been deleted.
+     * @return {Promise} Resolved when the project has been deleted.
      */
     this.deleteProject = function(opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Project Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Project Deleted');
     };
 
     /**
@@ -49,7 +51,8 @@ function ProjectClient(jiraClient) {
      * @method createProject
      * @memberOf ProjectClient#
      * @param project The project properties. See {@link https://docs.atlassian.com/jira/REST/latest/#api/2/project}
-     * @param callback Called when the project has been created.
+     * @param [callback] Called when the project has been created.
+     * @return {Promise} Resolved when the project has been created.
      */
     this.createProject = function (project, callback) {
         var options = {
@@ -60,7 +63,7 @@ function ProjectClient(jiraClient) {
             body: project
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -68,12 +71,14 @@ function ProjectClient(jiraClient) {
      *
      * @method getProjectProperties
      * @memberOf ProjectClient#
+     * @param opts Options
      * @param opts.projectIdOrKey The project id or project key
-     * @param callback Called when properties has been retrieved.
+     * @param [callback] Called when properties has been retrieved.
+     * @return {Promise} Resolved when properties has been retrieved.
      */
     this.getProjectProperties = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/properties', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
 
@@ -88,11 +93,12 @@ function ProjectClient(jiraClient) {
      * @memberOf ProjectClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.projectIdOrKey The project id or project key
-     * @param callback Called when the project is retrieved.
+     * @param [callback] Called when the project is retrieved.
+     * @return {Promise} Resolved when the project is retrieved.
      */
     this.getProject = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -102,11 +108,12 @@ function ProjectClient(jiraClient) {
      * @memberOf ProjectClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.projectIdOrKey The project id or project key
-     * @param callback Called when the components are retrieved.
+     * @param [callback] Called when the components are retrieved.
+     * @return {Promise} Resolved when the components are retrieved.
      */
     this.getComponents = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/components', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -116,11 +123,12 @@ function ProjectClient(jiraClient) {
      * @memberOf ProjectClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.projectIdOrKey The project id or project key
-     * @param callback Called when the statuses have been retrieved.
+     * @param [callback] Called when the statuses have been retrieved.
+     * @return {Promise} Resolved when the statuses have been retrieved.
      */
     this.getStatuses = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/statuses', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -130,11 +138,12 @@ function ProjectClient(jiraClient) {
      * @memberOf ProjectClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.projectIdOrKey The project id or project key
-     * @param callback Called when the versions have been retrieved.
+     * @param [callback] Called when the versions have been retrieved.
+     * @return {Promise} Resolved when the versions have been retrieved.
      */
     this.getVersions = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/versions', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -144,11 +153,12 @@ function ProjectClient(jiraClient) {
      * @memberOf ProjectClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.projectIdOrKey The project id or project key
-     * @param callback Called when the roles have been retrieved.
+     * @param [callback] Called when the roles have been retrieved.
+     * @return {Promise} Resolved when the roles have been retrieved.
      */
     this.getRoles = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/role', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -159,11 +169,12 @@ function ProjectClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.projectIdOrKey The project id or project key
      * @param opts.roleId The id of the role to retrieve.
-     * @param callback Called when the roles have been retrieved.
+     * @param [callback] Called when the roles have been retrieved.
+     * @return {Promise} Resolved when the roles have been retrieved.
      */
     this.getRole = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/role/' + opts.roleId, 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -175,11 +186,12 @@ function ProjectClient(jiraClient) {
      * @param opts.projectIdOrKey The project id or project key
      * @param opts.roleId The id of the role to retrieve.
      * @param opts.newRole See {@link https://docs.atlassian.com/jira/REST/latest/#d2e108}
-     * @param callback Called when the roles have been retrieved.
+     * @param [callback] Called when the roles have been retrieved.
+     * @return {Promise} Resolved when the roles have been retrieved.
      */
     this.updateRole = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/role/' + opts.roleId, 'PUT', opts.newRole);
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -191,11 +203,12 @@ function ProjectClient(jiraClient) {
      * @param opts.projectIdOrKey The project id or project key
      * @param opts.roleId The id of the role to retrieve.
      * @param opts.newRole See {@link https://docs.atlassian.com/jira/REST/latest/#d2e134}
-     * @param callback Called when the roles have been retrieved.
+     * @param [callback] Called when the roles have been retrieved.
+     * @return {Promise} Resolved when the roles have been retrieved.
      */
     this.addToRole = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/role/' + opts.roleId, 'POST', opts.newRole);
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**

--- a/api/projectCategory.js
+++ b/api/projectCategory.js
@@ -17,7 +17,8 @@ function ProjectCategoryClient(jiraClient) {
      * @method getAllProjectCategories
      * @memberOf ProjectCategoryClient#
      * @param opts Ignored
-     * @param callback Called when the statusCategories have been retrieved.
+     * @param [callback] Called when the statusCategories have been retrieved.
+     * @return {Promise} Resolved when the statusCategories have been retrieved.
      */
     this.getAllProjectCategories = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function ProjectCategoryClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function ProjectCategoryClient(jiraClient) {
      * @memberOf ProjectCategoryClient#
      * @param opts The options sent to the Jira API
      * @param opts.projectCategoryId A String containing a projectCategory id
-     * @param callback Called when the projectCategory has been retrieved.
+     * @param [callback] Called when the projectCategory has been retrieved.
+     * @return {Promise} Resolved when the projectCategory has been retrieved.
      */
     this.getProjectCategory = function (opts, callback) {
         var options = {
@@ -47,6 +49,6 @@ function ProjectCategoryClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/projectValidate.js
+++ b/api/projectValidate.js
@@ -20,7 +20,8 @@ function ProjectValidateClient(jiraClient) {
      * @memberOf ProjectValidateClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.projectKey The key of the project.
-     * @param callback Called when the key has been validated.
+     * @param [callback] Called when the key has been validated.
+     * @return {Promise} Resolved when the key has been validated.
      */
     this.validateProjectKey = function (opts, callback) {
         var options = {
@@ -33,6 +34,6 @@ function ProjectValidateClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/reindex.js
+++ b/api/reindex.js
@@ -23,7 +23,8 @@ function ReindexClient(jiraClient) {
      *     foreground reindex, where comments are always reindexed.
      * @param {boolean} [opts.indexChangeHistory=false] Indicates that changeHistory should also be reindexed. Not
      *     relevant for foreground reindex, where changeHistory is always reindexed.
-     * @param callback Called when the reindex has been started.
+     * @param [callback] Called when the reindex has been started.
+     * @return {Promise} Resolved when the reindex has been started.
      */
     this.doReindex = function (opts, callback) {
         var options = {
@@ -38,7 +39,7 @@ function ReindexClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -52,7 +53,8 @@ function ReindexClient(jiraClient) {
      * @param [opts.taskId] The id of an indexing task you wish to obtain details on. If omitted, then defaults to the
      *     standard behaviour and returns information on the active reindex task, or the last task to run if no reindex
      *     is taking place. . If there is no reindexing task with that id then a 404 is returned.
-     * @param callback Called when the reindex data has been retrieved.
+     * @param [callback] Called when the reindex data has been retrieved.
+     * @return {Promise} Resolved when the reindex data has been retrieved.
      */
     this.getReindex = function (opts, callback) {
         var options = {
@@ -65,6 +67,6 @@ function ReindexClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/resolution.js
+++ b/api/resolution.js
@@ -17,7 +17,8 @@ function ResolutionClient(jiraClient) {
      * @method getAllResolutions
      * @memberOf ResolutionClient#
      * @param opts Ignored
-     * @param callback Called when the resolutions have been retrieved.
+     * @param [callback] Called when the resolutions have been retrieved.
+     * @return {Promise} Resolved when the resolutions have been retrieved.
      */
     this.getAllResolutions = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function ResolutionClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function ResolutionClient(jiraClient) {
      * @memberOf ResolutionClient#
      * @param opts The options sent to the Jira API
      * @param opts.resolutionId A String containing a resolution id
-     * @param callback Called when the resolution has been retrieved.
+     * @param [callback] Called when the resolution has been retrieved.
+     * @return {Promise} Resolved when the resolution has been retrieved.
      */
     this.getResolution = function (opts, callback) {
         var options = {
@@ -47,6 +49,6 @@ function ResolutionClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/screens.js
+++ b/api/screens.js
@@ -18,11 +18,12 @@ function ScreensClient(jiraClient) {
      * @memberOf ScreensClient#
      * @param {Object} opts The request options sent to Jira
      * @param {number} opts.screenId The id of the screen to retrieve.
-     * @param callback Called when the available fields have been retrieved
+     * @param [callback] Called when the available fields have been retrieved
+     * @return {Promise} Resolved when the available fields have been retrieved
      */
     this.getAvailableFields = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/availableFields', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -32,11 +33,12 @@ function ScreensClient(jiraClient) {
      * @memberOf ScreensClient#
      * @param {Object} opts The request options sent to Jira
      * @param {number} opts.screenId The id of the screen to retrieve.
-     * @param callback Called when the tabs have been retrieved.
+     * @param [callback] Called when the tabs have been retrieved.
+     * @return {Promise} Resolved when the tabs have been retrieved.
      */
     this.getTabs = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -47,11 +49,12 @@ function ScreensClient(jiraClient) {
      * @param {Object} opts The request options sent to Jira
      * @param {number} opts.screenId The id of the screen in which to create a tab.
      * @param {string} opts.name The name of the tab to add.  Minimum required to create a tab.
-     * @param callback Called when the tab has been created.
+     * @param [callback] Called when the tab has been created.
+     * @return {Promise} Resolved when the tab has been created.
      */
     this.createTab = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs', 'POST', {name: opts.name});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -63,11 +66,12 @@ function ScreensClient(jiraClient) {
      * @param {number} opts.screenId The id of the screen containing the tab to rename.
      * @param {number} opts.tabId The id of the tab to rename
      * @param {string} opts.name The new name of the tab.
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.renameTab = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs/' + opts.tabId, 'PUT', {name: opts.name});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -78,11 +82,12 @@ function ScreensClient(jiraClient) {
      * @param {Object} opts The request options sent to the jira API
      * @param {number} opts.screenId The id of the screen containing the tab to delete.
      * @param {number} opts.tabId The id of the tab to delete
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.deleteTab = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs/' + opts.tabId, 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Tab Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Tab Deleted');
     };
 
     /**
@@ -94,11 +99,12 @@ function ScreensClient(jiraClient) {
      * @param {number} opts.screenId The id of the screen containing the tab.
      * @param {number} opts.tabId the id of the tab to which the fields will be added.
      * @param {string} opts.fieldId The field to add
-     * @param callback Called when the fields have been added to the tab.
+     * @param [callback] Called when the fields have been added to the tab.
+     * @return {Promise} Resolved when the fields have been added to the tab.
      */
     this.addFieldToTab = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs/' + opts.tabId + '/fields', 'POST', opts.fieldId);
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -109,11 +115,12 @@ function ScreensClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.screenId The id of the screen containing the tab.
      * @param {number} opts.tabId the id of the tab for which to retrieve fields.
-     * @param callback Called when the fields have been retrieved.
+     * @param [callback] Called when the fields have been retrieved.
+     * @return {Promise} Resolved when the fields have been retrieved.
      */
     this.getFieldsInTab = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs/' + opts.tabId + '/fields', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -125,11 +132,12 @@ function ScreensClient(jiraClient) {
      * @param {number} opts.screenId The id of the screen containing the tab.
      * @param {number} opts.tabId the id of the tab from which to remove the field.
      * @param {string} opts.fieldId The id of the field to remove from the tab.
-     * @param callback Called when the field has been removed.
+     * @param [callback] Called when the field has been removed.
+     * @return {Promise} Resolved when the field has been removed.
      */
     this.removeFieldFromTab = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs/' + opts.tabId + '/fields/' + opts.fieldId, 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Field Removed From Tab');
+        return this.jiraClient.makeRequest(options, callback, 'Field Removed From Tab');
     };
 
     /**
@@ -146,12 +154,13 @@ function ScreensClient(jiraClient) {
      *  * Later
      *  * First
      *  * Last
-     * @param callback Called when the field has been removed.
+     * @param [callback] Called when the field has been removed.
+     * @return {Promise} Resolved when the field has been removed.
      */
     this.moveFieldOnTab = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs/' + opts.tabId + '/fields/' + opts.fieldId + '/move',
             'POST', {position: opts.newPosition});
-        this.jiraClient.makeRequest(options, callback, 'Field Moved');
+        return this.jiraClient.makeRequest(options, callback, 'Field Moved');
     };
 
     /**
@@ -163,11 +172,12 @@ function ScreensClient(jiraClient) {
      * @param {number} opts.screenId The id of the screen containing the tab.
      * @param {number} opts.tabId the id of the tab to move.
      * @param {number} opts.newPosition The new (zero-indexed) position of the tab.
-     * @param callback Called when the tab has been moved.
+     * @param [callback] Called when the tab has been moved.
+     * @return {Promise} Resolved when the tab has been moved.
      */
     this.moveTabPosition = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/tabs/' + opts.tabId + '/move/' + opts.newPosition, 'POST');
-        this.jiraClient.makeRequest(options, callback, 'Tab Moved');
+        return this.jiraClient.makeRequest(options, callback, 'Tab Moved');
     };
 
     /**
@@ -177,7 +187,8 @@ function ScreensClient(jiraClient) {
      * @memberOf ScreensClient#
      * @param {Object} opts The request options sent to the Jira API.
      * @param {string} opts.fieldId The id of the field to add to the default tab.
-     * @param callback Called when the tab has been moved.
+     * @param [callback] Called when the tab has been moved.
+     * @return {Promise} Resolved when the tab has been moved.
      */
     this.addFieldToDefaultTab = function (opts, callback) {
         var options = {
@@ -187,7 +198,7 @@ function ScreensClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**

--- a/api/search.js
+++ b/api/search.js
@@ -47,7 +47,8 @@ function SearchClient(jiraClient) {
      * @param {array} [opts.fields] The list of fields to return for each issue. By default, all navigable fields are
      *     returned.
      * @param {array} [opts.expand] A list of the parameters to expand.
-     * @param callback Called with the search results.
+     * @param [callback] Called with the search results.
+     * @return {Promise} Resolved with the search results.
      */
     this.search = function (opts, callback) {
         opts.method = opts.method || 'POST';
@@ -56,7 +57,7 @@ function SearchClient(jiraClient) {
             uri: this.jiraClient.buildURL('/search'),
             method: opts.method, 
             json: true,
-            followAllRedirects: true,
+            followAllRedirects: true
 
         };
 
@@ -76,6 +77,6 @@ function SearchClient(jiraClient) {
         }
 
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/securityLevel.js
+++ b/api/securityLevel.js
@@ -18,7 +18,8 @@ function SecurityLevelClient(jiraClient) {
      * @memberOf SecurityLevelClient#
      * @param opts The request options to send to the Jira API.
      * @param opts.securityLevelId The id of the security level to retrieve
-     * @param callback Called when the security level has been retrieved.
+     * @param [callback] Called when the security level has been retrieved.
+     * @return {Promise} Resolved when the security level has been retrieved.
      */
     this.getSecurityLevel = function (opts, callback) {
         var options = {
@@ -28,6 +29,6 @@ function SecurityLevelClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/serverInfo.js
+++ b/api/serverInfo.js
@@ -17,7 +17,8 @@ function ServerInfoClient(jiraClient) {
      * @memberOf ServerInfoClient#
      * @param opts The request options sent to the Jira API.
      * @param {boolean} [opts.doHealthCheck] Whether to perform a health check on the server.
-     * @param callback Called when the server info has been retrieved.
+     * @param [callback] Called when the server info has been retrieved.
+     * @return {Promise} Resolved when the server info has been retrieved.
      */
     this.getServerInfo = function (opts, callback) {
         var options = {
@@ -30,6 +31,6 @@ function ServerInfoClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     }
 }

--- a/api/settings.js
+++ b/api/settings.js
@@ -17,7 +17,8 @@ function SettingsClient(jiraClient) {
      * @memberOf SettingsClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.newUrl The new base url.
-     * @param callback Called when the base url has been set.
+     * @param [callback] Called when the base url has been set.
+     * @return {Promise} Resolved when the base url has been set.
      */
     this.setBaseUrl = function (opts, callback) {
         var options = {
@@ -28,7 +29,7 @@ function SettingsClient(jiraClient) {
             body: opts.newUrl
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function SettingsClient(jiraClient) {
      * @method getIssueNavColumns
      * @memberOf SettingsClient#
      * @param opts Ignored
-     * @param callback Called when the columns have been retrieved
+     * @param [callback] Called when the columns have been retrieved
+     * @return {Promise} Resolved when the columns have been retrieved
      */
     this.getIssueNavColumns = function (opts, callback) {
         var options = {
@@ -47,6 +49,6 @@ function SettingsClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/sprint.js
+++ b/api/sprint.js
@@ -17,7 +17,8 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {Object} sprint The sprint data in the form of POST body to the
    *   Jira API.
-   * @param callback Called when the sprint has been created.
+   * @param [callback] Called when the sprint has been created.
+   * @return {Promise} Resolved when the sprint has been created.
    */
   this.createSprint = function (sprint, callback) {
     var options = {
@@ -28,7 +29,7 @@ function AgileSprintClient(jiraClient) {
       body: sprint
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -38,7 +39,8 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {object} opts The request options sent to the Jira API.
    * @param opts.sprintId The sprint id.
-   * @param callback Called when the sprint has been retrieved.
+   * @param [callback] Called when the sprint has been retrieved.
+   * @return {Promise} Resolved when the sprint has been retrieved.
    */
   this.getSprint = function (opts, callback) {
     var options = {
@@ -53,7 +55,7 @@ function AgileSprintClient(jiraClient) {
       }
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -64,7 +66,8 @@ function AgileSprintClient(jiraClient) {
    * @param {Object} sprint The sprint data in the form of PUT body to the
    *   Jira API.
    * @param {string} [sprint.sprintId] The id of the sprint.  EX: 331
-   * @param callback Called when the sprint has been updated.
+   * @param [callback] Called when the sprint has been updated.
+   * @return {Promise} Resolved when the sprint has been updated.
    */
   this.updateSprint = function (sprint, callback) {
     var sprintId = sprint.sprintId;
@@ -78,7 +81,7 @@ function AgileSprintClient(jiraClient) {
       body: sprint
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -90,6 +93,7 @@ function AgileSprintClient(jiraClient) {
    *   Jira API.
    * @param {string} [sprint.sprintId] The id of the sprint.  EX: 331.
    * @param callback Called when the sprint has been updated.
+   * @return {Promise} Resolved when the sprint has been updated.
    */
   this.partiallyUpdateSprint = function (sprint, callback) {
     var sprintId = sprint.sprintId;
@@ -103,7 +107,7 @@ function AgileSprintClient(jiraClient) {
       body: sprint
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -113,7 +117,8 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {Object} opts The request options sent to the Jira API.
    * @param {string} opts.sprintId The id of the sprint.  EX: 331
-   * @param callback Called when the sprint is deleted.
+   * @param [callback] Called when the sprint is deleted.
+   * @return {Promise} Resolved when the sprint is deleted.
    */
   this.deleteSprint = function (opts, callback) {
     var options = {
@@ -128,7 +133,7 @@ function AgileSprintClient(jiraClient) {
       }
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -142,7 +147,8 @@ function AgileSprintClient(jiraClient) {
    * @param {boolean} validateQuery Specifies whether to valide the JQL query.
    * @param {string} fields The list of fields to return for each issue.
    * @param {string} expand A comma-separated list of the parameters to expand.
-   * @param callback Called when the issues are returned.
+   * @param [callback] Called when the issues are returned.
+   * @return {Promise} Resolved when the issues are returned.
    */
   this.getSprintIssues = function (opts, callback) {
     var options = {
@@ -160,7 +166,7 @@ function AgileSprintClient(jiraClient) {
       }
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -171,7 +177,8 @@ function AgileSprintClient(jiraClient) {
    * @param {Object} opts The issue data in the form of POST body to the
    *   Jira API.
    * @param {string} [opts.sprintId] The sprint id.
-   * @param callback Called when the sprint has been retrieved.
+   * @param [callback] Called when the sprint has been retrieved.
+   * @return {Promise} Resolved when the sprint has been retrieved.
    */
   this.moveSprintIssues = function (opts, callback) {
     var sprintId = opts.sprintId;
@@ -185,7 +192,7 @@ function AgileSprintClient(jiraClient) {
       body: opts
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
   /**
@@ -196,7 +203,8 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {Object} swapped The data in the form of POST body to the Jira API.
    * @param {string} [swapped.sprintId] The id of the sprint.  EX: 311
-   * @param callback Called when the sprint has been retrived.
+   * @param [callback] Called when the sprint has been retrived.
+   * @return {Promise} Resolved when the sprint has been retrived.
    */
   this.swapSprint = function (swapped, callback) {
     var sprintId = swapped.sprintId;
@@ -210,7 +218,7 @@ function AgileSprintClient(jiraClient) {
       body: swapped
     };
 
-    this.jiraClient.makeRequest(options, callback);
+    return this.jiraClient.makeRequest(options, callback);
   };
 
 }

--- a/api/status.js
+++ b/api/status.js
@@ -12,12 +12,13 @@ function StatusClient(jiraClient) {
     this.jiraClient = jiraClient;
 
     /**
-     * Returns a list of all statuss visible to the user
+     * Returns a list of all statuses visible to the user
      *
      * @method getAllStatuses
      * @memberOf StatusClient#
      * @param opts Ignored
-     * @param callback Called when the statuss have been retrieved.
+     * @param [callback] Called when statuses have been retrieved.
+     * @return {Promise} Resolved when statuses have been retrieved.
      */
     this.getAllStatuses = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function StatusClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function StatusClient(jiraClient) {
      * @memberOf StatusClient#
      * @param opts The options sent to the Jira API
      * @param opts.statusId A String containing a status id
-     * @param callback Called when the status has been retrieved.
+     * @param [callback] Called when the status has been retrieved.
+     * @return {Promise} Resolved when the status has been retrieved.
      */
     this.getStatus = function (opts, callback) {
         var options = {
@@ -47,6 +49,6 @@ function StatusClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/statusCategory.js
+++ b/api/statusCategory.js
@@ -17,7 +17,8 @@ function StatusCategoryClient(jiraClient) {
      * @method getAllStatusCategories
      * @memberOf StatusCategoryClient#
      * @param opts Ignored
-     * @param callback Called when the statusCategories have been retrieved.
+     * @param [callback] Called when the statusCategories have been retrieved.
+     * @return {Promise} Resolved when the statusCategories have been retrieved.
      */
     this.getAllStatusCategories = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function StatusCategoryClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function StatusCategoryClient(jiraClient) {
      * @memberOf StatusCategoryClient#
      * @param opts The options sent to the Jira API
      * @param opts.statusCategoryIdOrKey A String containing a statusCategory id
-     * @param callback Called when the statusCategory has been retrieved.
+     * @param [callback] Called when the statusCategory has been retrieved.
+     * @return {Promise} Resolved when the statusCategory has been retrieved.
      */
     this.getStatusCategory = function (opts, callback) {
         var options = {
@@ -47,6 +49,6 @@ function StatusCategoryClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/user.js
+++ b/api/user.js
@@ -23,7 +23,8 @@ function UserClient(jiraClient) {
      * @param opts.username The name of the user to retrieve.
      * @param opts.userKey The key of the user to retrieve.
      * @param {Object} opts.expand The fields to be expanded.
-     * @param callback Called when the user has been retrieved.
+     * @param [callback] Called when the user has been retrieved.
+     * @return {Promise} Resolved when the user has been retrieved.
      */
     this.getUser = function (opts, callback) {
         var options = {
@@ -45,7 +46,7 @@ function UserClient(jiraClient) {
             });
         }
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -56,7 +57,8 @@ function UserClient(jiraClient) {
      * @param opts The request options sent to the Jira API
      * @param opts.username The name of the user to delete.
      * @param opts.userKey The key of the user to delete.
-     * @param callback Called when the user has been deleted.
+     * @param [callback] Called when the user has been deleted.
+     * @return {Promise} Resolved when the user has been deleted.
      */
     this.deleteUser = function (opts, callback) {
         var options = {
@@ -70,7 +72,7 @@ function UserClient(jiraClient) {
             }
         };
 
-        this.jiraClient.makeRequest(options, callback, 'User removed.');
+        return this.jiraClient.makeRequest(options, callback, 'User removed.');
     };
 
     /**
@@ -81,7 +83,8 @@ function UserClient(jiraClient) {
      * @memberOf UserClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.user See {@link https://docs.atlassian.com/jira/REST/latest/#d2e4049}
-     * @param callback Called when the user has been created.
+     * @param [callback] Called when the user has been created.
+     * @return {Promise} Resolved when the user has been created.
      */
     this.createUser = function (opts, callback) {
         var options = {
@@ -92,7 +95,7 @@ function UserClient(jiraClient) {
             body: opts.user
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -105,7 +108,8 @@ function UserClient(jiraClient) {
      * @param opts.user See {@link https://docs.atlassian.com/jira/REST/latest/#d2e4081}
      * @param opts.username The name of the user to edit.
      * @param opts.userKey The key of the user to edit.
-     * @param callback Called when the user has been edited.
+     * @param [callback] Called when the user has been edited.
+     * @return {Promise} Resolved when the user has been edited.
      */
     this.editUser = function (opts, callback) {
         var options = {
@@ -120,7 +124,7 @@ function UserClient(jiraClient) {
             body: opts.user
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -136,7 +140,8 @@ function UserClient(jiraClient) {
      * @param {number} [opts.maxResults] The maximum number of users to return (defaults to 50). The maximum allowed
      *     value is 1000. If you specify a value that is higher than this number, your search results will be
      *     truncated.
-     * @param callback Called when the search results have been retrieved.
+     * @param [callback] Called when the search results have been retrieved.
+     * @return {Promise} Resolved when the search results have been retrieved.
      */
     this.multiProjectSearchAssignable = function (opts, callback) {
         var projectKeyString = '';
@@ -158,7 +163,7 @@ function UserClient(jiraClient) {
                 maxResults: opts.maxResults
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -178,7 +183,8 @@ function UserClient(jiraClient) {
      *     value is 1000. If you specify a value that is higher than this number, your search results will be
      *     truncated.
      * @param {number} [opts.actionDescriptorId]
-     * @param callback Called when the search results have been retrieved.
+     * @param [callback] Called when the search results have been retrieved.
+     * @return {Promise} Resolved when the search results have been retrieved.
      */
     this.searchAssignable = function (opts, callback) {
         var options = {
@@ -195,7 +201,7 @@ function UserClient(jiraClient) {
                 actionDescriptorId: opts.actionDescriptorId
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -207,7 +213,8 @@ function UserClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.username The username
      * @param {string} opts.filepath The path to the file to upload.
-     * @param callback Called when the temporary avatar has been uploaded.
+     * @param [callback] Called when the temporary avatar has been uploaded.
+     * @return {Promise} Resolved when the temporary avatar has been uploaded.
      */
     this.createTemporaryAvatar = function (opts, callback) {
         var extension = path.extname(opts.filepath).slice(1);
@@ -231,7 +238,7 @@ function UserClient(jiraClient) {
                 "Content-Type": 'image/' + extension
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -242,7 +249,8 @@ function UserClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.username The username
      * @param {Object} opts.avatarId The id of the temporary avatar to convert.
-     * @param callback Called when the avatar has been converted
+     * @param [callback] Called when the avatar has been converted
+     * @return {Promise} Resolved when the avatar has been converted
      */
     this.convertTemporaryAvatar = function (opts, callback) {
         var options = {
@@ -258,7 +266,7 @@ function UserClient(jiraClient) {
                 "X-Atlassian-Token": 'no-check'
             }
         };
-        this.jiraClient.makeRequest(options, callback, 'Avatar Converted');
+        return this.jiraClient.makeRequest(options, callback, 'Avatar Converted');
     };
 
     /**
@@ -269,7 +277,8 @@ function UserClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.username The username
      * @param {Object} opts.avatarId The id of the temporary avatar to delete.
-     * @param callback Called when the avatar has been deleted.
+     * @param [callback] Called when the avatar has been deleted.
+     * @return {Promise} Resolved when the avatar has been deleted.
      */
     this.deleteAvatar = function (opts, callback) {
         var options = {
@@ -281,7 +290,7 @@ function UserClient(jiraClient) {
                 username: opts.username
             }
         };
-        this.jiraClient.makeRequest(options, callback, 'Avatar Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Avatar Deleted');
     };
 
     /**
@@ -291,7 +300,8 @@ function UserClient(jiraClient) {
      * @memberOf UserClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.username The username
-     * @param callback Called when the avatars have been retrieved.
+     * @param [callback] Called when the avatars have been retrieved.
+     * @return {Promise} Resolved when the avatars have been retrieved.
      */
     this.getAvatars = function (opts, callback) {
         var options = {
@@ -303,7 +313,7 @@ function UserClient(jiraClient) {
                 username: opts.username
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -314,7 +324,8 @@ function UserClient(jiraClient) {
      * @memberOf UserClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.username The username
-     * @param callback Called when the columns have been retrieved.
+     * @param [callback] Called when the columns have been retrieved.
+     * @return {Promise} Resolved when the columns have been retrieved.
      */
     this.getDefaultColumns = function (opts, callback) {
         var options = {
@@ -326,7 +337,7 @@ function UserClient(jiraClient) {
                 username: opts.username
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -339,7 +350,8 @@ function UserClient(jiraClient) {
      * @param {string} opts.username The username
      * @param {Array} opts.columns The names of the new columns.  See {@link
         *     https://docs.atlassian.com/jira/REST/latest/#d2e4566}
-     * @param callback Called when the columns have been set.
+     * @param [callback] Called when the columns have been set.
+     * @return {Promise} Resolved when the columns have been set.
      */
     this.setDefaultColumns = function (opts, callback) {
         var options = {
@@ -354,7 +366,7 @@ function UserClient(jiraClient) {
                 columns: opts.columns
             }
         };
-        this.jiraClient.makeRequest(options, callback, 'Default Columns Set');
+        return this.jiraClient.makeRequest(options, callback, 'Default Columns Set');
     };
 
     /**
@@ -365,7 +377,8 @@ function UserClient(jiraClient) {
      * @memberOf UserClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} opts.username The username
-     * @param callback Called when the columns have been reset.
+     * @param [callback] Called when the columns have been reset.
+     * @return {Promise} Resolved when the columns have been reset.
      */
     this.resetDefaultColumns = function (opts, callback) {
         var options = {
@@ -377,7 +390,7 @@ function UserClient(jiraClient) {
                 username: opts.username
             }
         };
-        this.jiraClient.makeRequest(options, callback, 'Default Columns Reset');
+        return this.jiraClient.makeRequest(options, callback, 'Default Columns Reset');
     };
 
     /**
@@ -389,7 +402,8 @@ function UserClient(jiraClient) {
      * @param opts.username The name of the user for which to change the password.
      * @param opts.userKey The key of the user for which to change the password.
      * @param opts.password The new password.
-     * @param callback Called when the password has been set.
+     * @param [callback] Called when the password has been set.
+     * @return {Promise} Resolved when the password has been set.
      */
     this.changePassword = function (opts, callback) {
         var options = {
@@ -405,7 +419,7 @@ function UserClient(jiraClient) {
                 password: opts.password
             }
         };
-        this.jiraClient.makeRequest(options, callback, 'Password Changed');
+        return this.jiraClient.makeRequest(options, callback, 'Password Changed');
     };
 
     /**
@@ -429,7 +443,8 @@ function UserClient(jiraClient) {
      * @param {number} [opts.maxResults] the maximum number of users to return (defaults to 50). The maximum allowed
      *     value is 1000. If you specify a value that is higher than this number, your search results will be
      *     truncated.
-     * @param callback Called when the search results are retrieved.
+     * @param [callback] Called when the search results are retrieved.
+     * @return {Promise} Resolved when the search results are retrieved.
      */
     this.searchPermissions = function (opts, callback) {
         var permissions = '';
@@ -453,7 +468,7 @@ function UserClient(jiraClient) {
                 maxResults: opts.maxResults
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -466,7 +481,8 @@ function UserClient(jiraClient) {
      * @param {number} [opts.maxResults=50]
      * @param {boolean} [opts.showAvatar=false]
      * @param {string} [opts.exclude]
-     * @param callback Called when the search results are retrieved.
+     * @param [callback] Called when the search results are retrieved.
+     * @return {Promise} Resolved when the search results are retrieved.
      */
     this.searchPicker = function (opts, callback) {
         var options = {
@@ -481,7 +497,7 @@ function UserClient(jiraClient) {
                 exclude: opts.exclude
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -498,7 +514,8 @@ function UserClient(jiraClient) {
      * @param {boolean} [opts.includeActive=true] If true, then active users are included in the results (default true)
      * @param {boolean} [opts.includeInactive=false] If true, then inactive users are included in the results (default
      *     false)
-     * @param callback Called when the search results are retrieved.
+     * @param [callback] Called when the search results are retrieved.
+     * @return {Promise} Resolved when the search results are retrieved.
      */
     this.search = function (opts, callback) {
         var options = {
@@ -514,7 +531,7 @@ function UserClient(jiraClient) {
                 includeInactive: opts.includeInactive
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -530,7 +547,8 @@ function UserClient(jiraClient) {
      * @param {string} [opts.projectKey] the optional project key to search for users with if no issueKey is supplied.
      * @param {number} [opts.startAt=0] the index of the first user to return (0-based)
      * @param {number} [opts.maxResults=50] the maximum number of users to return (defaults to 50). The maximum allowed
-     * @param callback
+     * @param [callback] Called when data has been retrieved
+     * @return {Promise} Resolved when data has been retrieved
      */
     this.viewIssueSearch = function (opts, callback) {
         var options = {
@@ -546,6 +564,6 @@ function UserClient(jiraClient) {
                 maxResults: opts.maxResults
             }
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/version.js
+++ b/api/version.js
@@ -17,7 +17,8 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param {Object} opts The request options sent to Jira.
      * @param {Object} opts.version See {@link https://docs.atlassian.com/jira/REST/latest/#d2e3549}
-     * @param callback Called when the version has been created.
+     * @param [callback] Called when the version has been created.
+     * @return {Promise} Resolved when the version has been created.
      */
     this.createVersion = function (opts, callback) {
         var options = {
@@ -28,7 +29,7 @@ function VersionClient(jiraClient) {
             body: opts.version
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -43,11 +44,12 @@ function VersionClient(jiraClient) {
      *     'Later'. Must be provided if opts.after is missing.
      * @param {string} [opts.after] A version to place this version after. The value should be the self link of another
      *     version. Must be provided if opts.position is missing
-     * @param callback Called when the version has been moved.
+     * @param [callback] Called when the version has been moved.
+     * @return {Promise} Resolved when the version has been moved.
      */
     this.moveVersion = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/move', 'POST', {position: opts.position, after: opts.after});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -57,11 +59,12 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param {Object} opts The request options sent to the Jira API.
      * @param {string|number} opts.versionId The id of the version to retrieve.
-     * @param callback Called when the version is retrieved.
+     * @param [callback] Called when the version is retrieved.
+     * @return {Promise} Resolved when the version is retrieved.
      */
     this.getVersion = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -72,11 +75,12 @@ function VersionClient(jiraClient) {
      * @param {Object} opts The request options sent to Jira.
      * @param {string} opts.versionId The id of the version to edit.
      * @param {Object} opts.version See {@link https://docs.atlassian.com/jira/REST/latest/#d2e3619}
-     * @param callback Called when the version has been modified.
+     * @param [callback] Called when the version has been modified.
+     * @return {Promise} Resolved when the version has been modified.
      */
     this.editVersion = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'PUT', opts.version);
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -86,11 +90,12 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.versionId The version for which to retrieve related issues.
-     * @param callback Called when the count has been retrieved.
+     * @param [callback] Called when the count has been retrieved.
+     * @return {Promise} Resolved when the count has been retrieved.
      */
     this.getRelatedIssueCounts = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/relatedIssueCounts', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -100,11 +105,12 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.versionId The version for which to retrieve unresolved issues.
-     * @param callback Called when the count has been retrieved.
+     * @param [callback] Called when the count has been retrieved.
+     * @return {Promise} Resolved when the count has been retrieved.
      */
     this.getUnresolvedIssueCount = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/unresolvedIssueCount', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -114,11 +120,12 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.versionId The version for which to retrieve remote links.
-     * @param callback Called when the links have been retrieved.
+     * @param [callback] Called when the links have been retrieved.
+     * @return {Promise} Resolved when the links have been retrieved.
      */
     this.getRemoteLinks = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/remotelink', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -130,11 +137,12 @@ function VersionClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.versionId The version for which to retrieve unresolved issues.
      * @param opts.remoteLink See {@link https://docs.atlassian.com/jira/REST/latest/#d2e3753}
-     * @param callback Called when the remote link has been created.
+     * @param [callback] Called when the remote link has been created.
+     * @return {Promise} Resolved when the remote link has been created.
      */
     this.createRemoteLink = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/remotelink', 'POST', opts.remoteLink);
-        this.jiraClient.makeRequest(options, callback, 'Remotelink Created');
+        return this.jiraClient.makeRequest(options, callback, 'Remotelink Created');
     };
 
     /**
@@ -145,11 +153,12 @@ function VersionClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.versionId The version for which to retrieve the remote link
      * @param opts.remoteLinkId The global id of the remote link
-     * @param callback Called when the link has been retrieved.
+     * @param [callback] Called when the link has been retrieved.
+     * @return {Promise} Resolved when the link has been retrieved.
      */
     this.getRemoteLink = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/remotelink/' + opts.remoteLinkId, 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -160,11 +169,12 @@ function VersionClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.versionId The version id
      * @param opts.remoteLinkId The global id of the remote link
-     * @param callback Called when the link has been deleted.
+     * @param [callback] Called when the link has been deleted.
+     * @return {Promise} Resolved when the link has been deleted.
      */
     this.deleteRemoteLink = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/remotelink/' + opts.remoteLinkId, 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Remote Link Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Remote Link Deleted');
     };
 
     /**
@@ -174,11 +184,12 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param {Object} opts The request options sent to the Jira API.
      * @param {string|number} opts.versionId The id of the version to delete.
-     * @param callback Called when the version is deleted.
+     * @param [callback] Called when the version is deleted.
+     * @return {Promise} Resolved when the version is deleted.
      */
     this.deleteVersion = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Version Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Version Deleted');
     };
 
     /**
@@ -188,11 +199,12 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param {Object} opts The request options sent to the Jira API.
      * @param {string|number} opts.versionId The id of the version to delete.
-     * @param callback Called when the version is deleted.
+     * @param [callback] Called when the version is deleted.
+     * @return {Promise} Resolved when the version is deleted.
      */
     this.deleteAllRemoteLinks = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/remotelink', 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Remote Links Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Remote Links Deleted');
     };
 
     /**
@@ -202,7 +214,8 @@ function VersionClient(jiraClient) {
      * @memberOf VersionClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.globalId The global id of the remote resource that is linked to the versions
-     * @param callback Called when the remote link is returned.
+     * @param [callback] Called when the remote link is returned.
+     * @return {Promise} Resolved when the remote link is returned.
      */
     this.getGlobalRemoteLink = function (opts, callback) {
         var options = {
@@ -212,7 +225,7 @@ function VersionClient(jiraClient) {
             followAllRedirects: true,
             qs: {globalId: opts.globalId}
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -17,7 +17,8 @@ function WebhookClient(jiraClient) {
      * @method getAllWebhooks
      * @memberOf WebhookClient#
      * @param opts Ignored
-     * @param callback Called when the webhooks have been retrieved.
+     * @param [callback] Called when the webhooks have been retrieved.
+     * @return {Promise} Resolved when the webhooks have been retrieved.
      */
     this.getAllWebhooks = function (opts, callback) {
         var options = {
@@ -27,7 +28,7 @@ function WebhookClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -37,7 +38,8 @@ function WebhookClient(jiraClient) {
      * @memberOf WebhookClient#
      * @param opts The options sent to the JIRA API.
      * @param opts.webhookId The numerical webhook ID.
-     * @param callback Called when the webhook has been retrieved.
+     * @param [callback] Called when the webhook has been retrieved.
+     * @return {Promise} Resolved when the webhook has been retrieved.
      */
     this.getWebhook = function (opts, callback) {
         var options = {
@@ -47,7 +49,7 @@ function WebhookClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -64,7 +66,8 @@ function WebhookClient(jiraClient) {
      * @param opts.filter An object containing filter configuration.
      * @param opts.filter.issue-related-events-section A filter for issues, written in JQL.
      * @param opts.excludeBody Whether to send an empty body to the webhook URL.
-     * @param callback Called when the webhook has been retrieved.
+     * @param [callback] Called when the webhook has been retrieved.
+     * @return {Promise} Resolved when the webhook has been retrieved.
      */
     this.createWebhook = function (opts, callback) {
         var options = {
@@ -75,7 +78,7 @@ function WebhookClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -85,7 +88,8 @@ function WebhookClient(jiraClient) {
      * @memberOf WebhookClient#
      * @param opts The options sent to the JIRA API.
      * @param opts.webhookId The numerical webhook ID.
-     * @param callback Called when the webhook has been retrieved.
+     * @param [callback] Called when the webhook has been retrieved.
+     * @return {Promise} Resolved when the webhook has been retrieved.
      */
     this.deleteWebhook = function (opts, callback) {
         var options = {
@@ -95,6 +99,6 @@ function WebhookClient(jiraClient) {
             followAllRedirects: true
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/workflow.js
+++ b/api/workflow.js
@@ -18,7 +18,8 @@ function WorkflowClient(jiraClient) {
      * @memberOf WorkflowClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {string} [opts.workflowName] The name of the workflow to retrieve.
-     * @param callback Called when the workflow(s) have been retrieved.
+     * @param [callback] Called when the workflow(s) have been retrieved.
+     * @return {Promise} Resolved when the workflow(s) have been retrieved.
      */
     this.getWorkflows = function (opts, callback) {
         var qs = {};
@@ -33,6 +34,6 @@ function WorkflowClient(jiraClient) {
             qs: qs
         };
 
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 }

--- a/api/workflowScheme.js
+++ b/api/workflowScheme.js
@@ -18,7 +18,8 @@ function WorkflowSchemeClient(jiraClient) {
      * @memberOf WorkflowSchemeClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowScheme See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2196}
-     * @param callback Called when the workflow scheme has been created.
+     * @param [callback] Called when the workflow scheme has been created.
+     * @return {Promise} Resolved when the workflow scheme has been created.
      */
     this.createWorkflowScheme = function (opts, callback) {
         var options = {
@@ -28,7 +29,7 @@ function WorkflowSchemeClient(jiraClient) {
             followAllRedirects: true,
             body: opts.workflowScheme
         };
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -43,11 +44,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.workflowScheme See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2305}
-     * @param callback Called when the workflow scheme has been edited.
+     * @param [callback] Called when the workflow scheme has been edited.
+     * @return {Promise} Resolved when the workflow scheme has been edited.
      */
     this.editWorkflowScheme = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'PUT', opts.workflowScheme);
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -59,11 +61,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param [opts.returnDraftIfExists=false] when true indicates that a scheme's draft, if it exists, should be
      *     queried instead of the scheme itself.
-     * @param callback Called when the workflow scheme has been retrieved.
+     * @param [callback] Called when the workflow scheme has been retrieved.
+     * @return {Promise} Resolved when the workflow scheme has been retrieved.
      */
     this.getWorkflowScheme = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'GET', null, {returnDraftIfExists: opts.returnDraftIfExists});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -73,11 +76,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @memberOf WorkflowSchemeClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
-     * @param callback Called when the workflow scheme has been deleted.
+     * @param [callback] Called when the workflow scheme has been deleted.
+     * @return {Promise} Resolved when the workflow scheme has been deleted.
      */
     this.deleteWorkflowScheme = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '', 'DELETE');
-        this.jiraClient.makeRequest(options, callback, 'Workflow Scheme Deleted');
+        return this.jiraClient.makeRequest(options, callback, 'Workflow Scheme Deleted');
     };
 
     /**
@@ -87,11 +91,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @memberOf WorkflowSchemeClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
-     * @param callback Called when the draft has been created.
+     * @param [callback] Called when the draft has been created.
+     * @return {Promise} Resolved when the draft has been created.
      */
     this.createDraft = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/createdraft', 'POST');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -103,11 +108,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.returnDraftIfExists when true indicates that a scheme's draft, if it exists, should be queried
      *     instead of the scheme itself.
-     * @param callback Called when the default workflow is returned.
+     * @param [callback] Called when the default workflow is returned.
+     * @return {Promise} Resolved when the default workflow is returned.
      */
     this.getDefaultWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/default', 'GET', null, {returnDraftIfExists: opts.returnDraftIfExists});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -119,11 +125,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.updateDraftIfNeeded when true will create and return a draft when the workflow scheme cannot be
      *     edited (e.g. when it is being used by a project).
-     * @param callback Called when the defaul workflow has been removed.
+     * @param [callback] Called when the defaul workflow has been removed.
+     * @return {Promise} Resolved when the defaul workflow has been removed.
      */
     this.removeDefaultWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/default', 'DELETE', null, {updateDraftIfNeeded: opts.updateDraftIfNeeded});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -136,14 +143,15 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts.workflowName The name of the new deafault workflow
      * @param opts.updateDraftIfNeeded when true will create and return a draft when the workflow scheme cannot be
      *     edited (e.g. when it is being used by a project).
-     * @param callback Called when the default workflow has been updated.
+     * @param [callback] Called when the default workflow has been updated.
+     * @return {Promise} Resolved when the default workflow has been updated.
      */
     this.setDefaultWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/default', 'PUT', {
             workflow: opts.workflowName,
             updateDraftIfNeeded: opts.updateDraftIfNeeded
         });
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -153,11 +161,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @memberOf WorkflowSchemeClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
-     * @param callback Called when the draft has been retrieved.
+     * @param [callback] Called when the draft has been retrieved.
+     * @return {Promise} Resolved when the draft has been retrieved.
      */
     this.getDraft = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -169,11 +178,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.draft See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2575}
-     * @param callback Called when the draft has been edited.
+     * @param [callback] Called when the draft has been edited.
+     * @return {Promise} Resolved when the draft has been edited.
      */
     this.editDraft = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft', 'PUT', opts.draft);
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -183,11 +193,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @memberOf WorkflowSchemeClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
-     * @param callback Called when the draft has been deleted.
+     * @param [callback] Called when the draft has been deleted.
+     * @return {Promise} Resolved when the draft has been deleted.
      */
     this.deleteDraft = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft', 'DELETE');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -197,11 +208,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @memberOf WorkflowSchemeClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
-     * @param callback Called when the default workflow is returned.
+     * @param [callback] Called when the default workflow is returned.
+     * @return {Promise} Resolved when the default workflow is returned.
      */
     this.getDraftDefaultWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/default', 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -212,14 +224,15 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.workflowName The name of the new default workflow
-     * @param callback Called when the default workflow has been updated.
+     * @param [callback] Called when the default workflow has been updated.
+     * @return {Promise} Resolved when the default workflow has been updated.
      */
     this.setDraftDefaultWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/default', 'PUT', {
             workflow: opts.workflowName,
             updateDraftIfNeeded: opts.updateDraftIfNeeded
         });
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -229,11 +242,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @memberOf WorkflowSchemeClient#
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
-     * @param callback Called when the defaul workflow has been removed.
+     * @param [callback] Called when the defaul workflow has been removed.
+     * @return {Promise} Resolved when the defaul workflow has been removed.
      */
     this.removeDraftDefaultWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/default', 'DELETE');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -246,12 +260,13 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts.issueType The issue type
      * @param opts.returnDraftIfExists when true indicates that a scheme's draft, if it exists, should be queried
      *     instead of the scheme itself.
-     * @param callback Called when the issue type has been retrieved.
+     * @param [callback] Called when the issue type has been retrieved.
+     * @return {Promise} Resolved when the issue type has been retrieved.
      */
     this.getIssueType = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/issuetype/' + opts.issueType, 'GET', null,
             {returnDraftIfExists: opts.returnDraftIfExists});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -266,14 +281,15 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts.workflow The new workflow
      * @param opts.updateDraftIfNeeded when true will create and return a draft when the workflow scheme cannot be
      *     edited (e.g. when it is being used by a project).
-     * @param callback Called when the issue type has been edited
+     * @param [callback] Called when the issue type has been edited
+     * @return {Promise} Resolved when the issue type has been edited
      */
     this.editIssueType = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/issuetype/' + opts.issueType, 'PUT', {
             workflow: opts.workflow,
             updateDraftIfNeeded: opts.updateDraftIfNeeded
         });
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -284,13 +300,14 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.issueType The issue type
-     * @param callback Called when the issue type mapping has been removed.
+     * @param [callback] Called when the issue type mapping has been removed.
+     * @return {Promise} Resolved when the issue type mapping has been removed.
      */
     this.removeIssueType = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/issuetype/' + opts.issueType, 'DELETE', null, {
             updateDraftIfNeeded: opts.updateDraftIfNeeded
         });
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -301,11 +318,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API.
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.issueType The issue type
-     * @param callback Called when the issue type has been retrieved.
+     * @param [callback] Called when the issue type has been retrieved.
+     * @return {Promise} Resolved when the issue type has been retrieved.
      */
     this.getDraftIssueType = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/issuetype/' + opts.issueType, 'GET');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -317,11 +335,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.issueType The issue type
      * @param opts.workflow The new workflow
-     * @param callback Called when the issue type has been edited
+     * @param [callback] Called when the issue type has been edited
+     * @return {Promise} Resolved when the issue type has been edited
      */
     this.editDraftIssueType = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/issuetype/' + opts.issueType, 'PUT', {workflow: opts.workflow});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -332,11 +351,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.issueType The issue type
-     * @param callback Called when the issue type mapping has been removed.
+     * @param [callback] Called when the issue type mapping has been removed.
+     * @return {Promise} Resolved when the issue type mapping has been removed.
      */
     this.removeDraftIssueType = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/issuetype/' + opts.issueType, 'DELETE');
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -347,13 +367,14 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.workflowName The name of the workflow.
-     * @param callback Called when the workflow has been retrieved.
+     * @param [callback] Called when the workflow has been retrieved.
+     * @return {Promise} Resolved when the workflow has been retrieved.
      */
     this.getWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/workflow', 'GET', null, {
             workflowName: opts.workflowName
         });
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -364,13 +385,14 @@ function WorkflowSchemeClient(jiraClient) {
      * @param opts The request options sent to the Jira API
      * @param opts.workflowSchemeId The id of the workflow scheme.
      * @param opts.workflowName The name of the workflow.
-     * @param callback Called when the workflow has been retrieved.
+     * @param [callback] Called when the workflow has been retrieved.
+     * @return {Promise} Resolved when the workflow has been retrieved.
      */
     this.getDraftWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/workflow', 'GET', null, {
             workflowName: opts.workflowName
         });
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -384,14 +406,15 @@ function WorkflowSchemeClient(jiraClient) {
      * @param {string} opts.workflowName The name of the workflow.
      * @param {Array} opts.issueTypes The new issue types to inclue in the workflow.
      *      See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2509}
-     * @param callback Called when the workflow has been edited.
+     * @param [callback] Called when the workflow has been edited.
+     * @return {Promise} Resolved when the workflow has been edited.
      */
     this.editWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/workflow', 'PUT', {
             workflow: opts.workflowName,
             issueTypes: opts.issueTypes
         }, {workflowName: opts.workflowName});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -405,14 +428,15 @@ function WorkflowSchemeClient(jiraClient) {
      * @param {string} opts.workflowName The name of the workflow.
      * @param {Array} opts.issueTypes The new issue types to inclue in the workflow.
      *      See {@link https://docs.atlassian.com/jira/REST/latest/#d2e2670 }
-     * @param callback Called when the workflow has been edited.
+     * @param [callback] Called when the workflow has been edited.
+     * @return {Promise} Resolved when the workflow has been edited.
      */
     this.editDraftWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/workflow', 'PUT', {
             workflow: opts.workflowName,
             issueTypes: opts.issueTypes
         }, {workflowName: opts.workflowName});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -423,11 +447,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.workflowSchemeId The id of the workflow scheme.
      * @param {string} opts.workflowName The name of the workflow.
-     * @param callback Called when the workflow has been edited.
+     * @param [callback] Called when the workflow has been edited.
+     * @return {Promise} Resolved when the workflow has been edited.
      */
     this.deleteWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/workflow', 'DELETE', null, {workflowName: opts.workflowName});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**
@@ -438,11 +463,12 @@ function WorkflowSchemeClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.workflowSchemeId The id of the workflow scheme.
      * @param {string} opts.workflowName The name of the workflow.
-     * @param callback Called when the workflow has been edited.
+     * @param [callback] Called when the workflow has been edited.
+     * @return {Promise} Resolved when the workflow has been edited.
      */
     this.deleteDraftWorkflow = function (opts, callback) {
         var options = this.buildRequestOptions(opts, '/draft/workflow', 'DELETE', null, {workflowName: opts.workflowName});
-        this.jiraClient.makeRequest(options, callback);
+        return this.jiraClient.makeRequest(options, callback);
     };
 
     /**

--- a/api/worklog.js
+++ b/api/worklog.js
@@ -20,7 +20,8 @@ function WorklogClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.since A date time in unix timestamp format since when deleted worklogs will be returned.
      *      Default: 0
-     * @param callback Called when the search results are retrieved.
+     * @param [callback] Called when the search results are retrieved.
+     * @return {Promise} Resolved when the search results are retrieved.
      */ 
     this.getWorklogDeleted = function (opts, callback) {
         var options = {
@@ -32,8 +33,8 @@ function WorklogClient(jiraClient) {
                 since: opts.since
             }
         };
-        this.jiraClient.makeRequest(options, callback)
-    }
+        return this.jiraClient.makeRequest(options, callback)
+    };
 
     /**
      * Returns Returns worklogs for given worklog ids. Only worklogs to which the calling user has permissions, 
@@ -43,7 +44,8 @@ function WorklogClient(jiraClient) {
      * @memberOf WorklogClient#
      * @param {Object} opts The request options sent to the Jira API
      * @param {array} [opts.ids] a JSON array named ids which contains a list of issue IDs
-     * @param callback Called when the search results are retrieved.
+     * @param [callback] Called when the search results are retrieved.
+     * @return {Promise} Resolved when the search results are retrieved.
      */ 
     this.worklogList = function (opts, callback) {
         var options = {
@@ -55,8 +57,8 @@ function WorklogClient(jiraClient) {
                 ids: opts.ids
             }
         };
-        this.jiraClient.makeRequest(options, callback)
-    }
+        return this.jiraClient.makeRequest(options, callback)
+    };
 
     /**
      * Returns worklogs id and update time of worklogs that were updated since given time. The returns set of worklogs is 
@@ -67,7 +69,8 @@ function WorklogClient(jiraClient) {
      * @param {Object} opts The request options sent to the Jira API
      * @param {number} opts.since A date time in unix timestamp format since when updated worklogs will be returned.
      *      Default: 0
-     * @param callback Called when the search results are retrieved.
+     * @param [callback] Called when the search results are retrieved.
+     * @return {Promise} Resolved when the search results are retrieved.
      */ 
     this.getWorklogUpdated = function (opts, callback) {
         var options = {
@@ -79,6 +82,6 @@ function WorklogClient(jiraClient) {
                 since: opts.since
             }
         };
-        this.jiraClient.makeRequest(options, callback)
+        return this.jiraClient.makeRequest(options, callback)
     }
 }

--- a/index.js
+++ b/index.js
@@ -126,6 +126,8 @@ var worklog = require('./api/worklog');
  *     OAuth.
  * @param {string} [config.oauth.token_secret] The secret for the above token.  MUST be included if using Oauth.
  * @param {CookieJar} [config.cookie_jar] The CookieJar to use for every requests.
+ * @param {Promise} [config.promise] Any function (constructor) compatible with Promise (bluebird, Q,...).
+ *      Default - native Promise.
  */
 var JiraClient = module.exports = function (config) {
     if(!config.host) {
@@ -138,6 +140,7 @@ var JiraClient = module.exports = function (config) {
     this.apiVersion = 2; // TODO Add support for other versions.
     this.agileApiVersion = '1.0';
     this.webhookApiVersion = '1.0';
+    this.promise = config.promise || Promise;
 
     if (config.oauth) {
         if (!config.oauth.consumer_key) {
@@ -294,8 +297,9 @@ var JiraClient = module.exports = function (config) {
      * @method makeRequest
      * @memberOf JiraClient#
      * @param options The request options.
-     * @param callback Called with the APIs response.
+     * @param [callback] Called with the APIs response.
      * @param {string} [successString] If supplied, this is reported instead of the response body.
+     * @return {Promise} Resolved with APIs response or rejected with error
      */
     this.makeRequest = function (options, callback, successString) {
         if (this.oauthConfig) {
@@ -312,10 +316,12 @@ var JiraClient = module.exports = function (config) {
         if (this.cookie_jar) {
             options.jar = this.cookie_jar;
         }
-        request(options, function (err, response, body) {
-            if (err || response.statusCode.toString()[0] != 2) {
-                return callback(err ? err : body, null, response);
-            }
+
+        if (callback) {
+            request(options, function (err, response, body) {
+                if (err || response.statusCode.toString()[0] != 2) {
+                    return callback(err ? err : body, null, response);
+                }
 
             if (typeof body == 'string') {
                 try {
@@ -325,8 +331,53 @@ var JiraClient = module.exports = function (config) {
                 }
             }
 
-            return callback(null, successString ? successString : body, response);
-        });
+                return callback(null, successString ? successString : body, response);
+            });
+        } else if (this.promise) {
+            return new this.promise(function (resolve, reject) {
+
+                var req = request(options);
+
+                req.on('response', function(response) {
+
+                    // Saving error
+                    var error = response.statusCode.toString()[0] !== '2';
+
+                    // Collecting data
+                    var body = [];
+                    var push = body.push.bind(body);
+                    response.on('data', push);
+
+                    // Data collected
+                    response.on('end', function () {
+
+                        var result = body.join('');
+
+                        // Parsing JSON
+                        if (result[0] === '[' || result[0] === '{') {
+                            try {
+                                result = JSON.parse(result);
+                            } catch(e) {
+                                // nothing to do
+                            }
+                        }
+
+                        if (error) {
+                            response.body = result;
+                            reject(JSON.stringify(response));
+                            return;
+                        }
+
+                        resolve(result);
+                    });
+
+                });
+
+                req.on('error', reject);
+
+            });
+        }
+
     };
 
 }).call(JiraClient.prototype);


### PR DESCRIPTION
If callback missing than method will return promise. By default using native Promise. 
I tried to make minimal changes to preserve backwards compatibility. #37 

Some methods throw error. I didn't change anything in it. Better to use methods from promise chain to catch those errors..

```
Promise.resolve().then(function () {
    return jira.myself.getMyself();
}).then(function (data) {
    console.log(data);
}).catch(function (err) {
    console.log(err);
});
```