### PR TITLE
Adding getIssuesForBacklog agile api method

### DIFF
--- a/api/board.js
+++ b/api/board.js
@@ -133,4 +133,36 @@ function AgileBoardClient(jiraClient) {
 
     return this.jiraClient.makeRequest(options, callback);
   };
+
+  /**
+   * Get a list of all issues from the board's backlog, for the given board Id.
+   *
+   * @method getIssuesForBacklog
+   * @memberOf AgileBoardClient#
+   * @param opts The request options to send to the Jira API
+   * @param opts.boardId The agile board id.
+   * @param [opts.startAt] The index of the first dashboard to return (0-based). must be 0 or a multiple of
+   *     maxResults
+   * @param [opts.maxResults] A hint as to the the maximum number of issues to return in each call. Note that the
+   *     JIRA server reserves the right to impose a maxResults limit that is lower than the value that a client
+   *     provides, dues to lack or resources or any other condition. When this happens, your results will be
+   *     truncated. Callers should always check the returned maxResults to determine the value that is effectively
+   *     being used.
+   * @param [callback] Called when the backlog issues have been retrieved.
+   * @return {Promise} Resolved when the backlog issues have been retrieved.
+   */
+  this.getIssuesForBacklog = function (opts, callback) {
+    var options = {
+      uri: this.jiraClient.buildAgileURL('/board/' + opts.boardId + '/backlog'),
+      method: 'GET',
+      json: true,
+      followAllRedirects: true,
+      qs: {
+        startAt: opts.startAt,
+        maxResults: opts.maxResults
+      }
+    };
+
+      return this.jiraClient.makeRequest(options, callback);
+  };
 }


### PR DESCRIPTION
just adding an implementation for getting backlog issues for a given boardId as seen here:

https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-getIssuesForBacklog