### PR TITLE
expande getIssuesForBoard + useQuerystring for fixing oauth get request

### DIFF
--- a/api/board.js
+++ b/api/board.js
@@ -138,4 +138,37 @@ function AgileBoardClient(jiraClient) {
 
     return this.jiraClient.makeRequest(options, callback);
   };
+
+    /**
+   * Get a list of projects associated board
+   *
+   * @method getProjectsForBoard
+   * @memberOf AgileBoardClient#
+   * @param opts The request options to send to the Jira API
+   * @param opts.boardId The agile board id.
+   * @param [opts.startAt] The index of the first sprint to return (0-based). must be 0 or a multiple of
+   *     maxResults
+   * @param [opts.maxResults] A hint as to the the maximum number of sprints to return in each call. Note that the
+   *     JIRA server reserves the right to impose a maxResults limit that is lower than the value that a client
+   *     provides, dues to lack or resources or any other condition. When this happens, your results will be
+   *     truncated. Callers should always check the returned maxResults to determine the value that is effectively
+   *     being used.
+   * @param callback Called when the sprints have been retrieved.
+   * @return {Promise} Resolved when the sprints have been retrieved.
+   */
+  this.getProjectsForBoard = function (opts, callback) {
+    var options = {
+      uri: this.jiraClient.buildAgileURL('/board/' + opts.boardId + '/project'),
+      method: 'GET',
+      json: true,
+      followAllRedirects: true,
+      qs: {
+        startAt: opts.startAt,
+        maxResults: opts.maxResults,
+      }
+    };
+
+    return this.jiraClient.makeRequest(options, callback);
+  };
+
 }

--- a/api/board.js
+++ b/api/board.js
@@ -130,7 +130,8 @@ function AgileBoardClient(jiraClient) {
       followAllRedirects: true,
       qs: {
         startAt: opts.startAt,
-        maxResults: opts.maxResults
+        maxResults: opts.maxResults,
+        state: opts.state,
       }
     };
 

--- a/api/board.js
+++ b/api/board.js
@@ -93,9 +93,12 @@ function AgileBoardClient(jiraClient) {
       method: 'GET',
       json: true,
       followAllRedirects: true,
+      useQuerystring: true,
       qs: {
         startAt: opts.startAt,
-        maxResults: opts.maxResults
+        maxResults: opts.maxResults,
+        fields: opts.fields,
+        jql: opts.jql
       }
     };
 

--- a/api/board.js
+++ b/api/board.js
@@ -95,7 +95,8 @@ function AgileBoardClient(jiraClient) {
       followAllRedirects: true,
       qs: {
         startAt: opts.startAt,
-        maxResults: opts.maxResults
+        maxResults: opts.maxResults,
+        jql: opts.jql
       }
     };
 

--- a/api/board.js
+++ b/api/board.js
@@ -94,6 +94,7 @@ function AgileBoardClient(jiraClient) {
       json: true,
       followAllRedirects: true,
       useQuerystring: true,
+      timeout: opts.timeout || 10000,
       qs: {
         startAt: opts.startAt,
         maxResults: opts.maxResults,

--- a/api/filter.js
+++ b/api/filter.js
@@ -60,6 +60,25 @@ function FilterClient(jiraClient) {
     };
 
     /**
+     * Returns all filters for the current user(only for cloud)
+     *
+     * @method getFilters
+     * @memberOf FilterClient#
+     * @param {Object} opts The request options sent to the Jira API
+     * @param [callback] Called when the filter has been retrieved.
+     * @return {Promise} Resolved when the filter has been retrieved.
+     */
+    this.getFilters = function (opts, callback) {
+       var options = {
+            uri: this.jiraClient.buildURL('/filter'),
+            method: 'GET',
+            json: true,
+            followAllRedirects: true
+        };
+        return this.jiraClient.makeRequest(options, callback);
+    };
+
+    /**
      * Updates an existing filter, and returns its new value.
      *
      * @method updateFilter

--- a/api/issue.js
+++ b/api/issue.js
@@ -1115,6 +1115,42 @@ function IssueClient(jiraClient) {
         return this.jiraClient.makeRequest(options, callback, 'Property Deleted');
     };
 
+    this.setWorklogProperty = function (opts, callback) {
+        if (!opts.propertyKey) {
+            throw new Error(errorStrings.NO_PROPERTY_KEY_ERROR);
+        } else if (!opts.propertyValue) {
+            throw new Error(errorStrings.NO_PROPERTY_VALUE_ERROR);
+        }
+      var options = this.buildRequestOptions(
+        opts,
+        '/worklog/' + opts.worklogId + '/properties/' + opts.propertyKey,
+        'PUT',
+        opts.propertyValue
+      );
+      return this.jiraClient.makeRequest(options, callback, 'Property Set');
+    };
+
+    this.getWorkLogProperties = function (opts, callback) {
+      var options = this.buildRequestOptions(
+        opts,
+        '/worklog/' + opts.worklogId + '/properties/',
+        'GET'
+      );
+      return this.jiraClient.makeRequest(options, callback);
+    };
+
+    this.getWorkLogProperty = function (opts, callback) {
+      if (!opts.propertyKey) {
+          throw new Error(errorStrings.NO_PROPERTY_KEY_ERROR);
+      }
+      var options = this.buildRequestOptions(
+        opts,
+        '/worklog/' + opts.worklogId + '/properties/' + opts.propertyKey,
+        'GET'
+      );
+      return this.jiraClient.makeRequest(options, callback);
+    };
+
     /**
      * Build out the request options necessary to make a particular API call.
      *

--- a/api/myPermissions.js
+++ b/api/myPermissions.js
@@ -41,7 +41,13 @@ function MyPermissionsClient(jiraClient) {
             uri: this.jiraClient.buildURL('/mypermissions'),
             method: 'GET',
             json: true,
-            followAllRedirects: true
+            followAllRedirects: true,
+            qs: {
+                issueId: opts.issueId,
+                issueKey: opts.issueKey,
+                projectId: opts.projectId,
+                projectKey: opts.projectKey,
+            },
         };
 
         return this.jiraClient.makeRequest(options, callback);

--- a/api/myself.js
+++ b/api/myself.js
@@ -20,12 +20,13 @@ function MyselfClient(jiraClient) {
      * @param [callback] Called when the current user is retrieved.
      * @return {Promise} Resolved when the current user is retrieved.
      */
-    this.getMyself = function (opts, callback) {
+    this.getMyself = function (debug, callback) {
         var options = {
             uri: this.jiraClient.buildURL('/myself'),
             method: 'GET',
             json: true,
-            followAllRedirects: true
+            followAllRedirects: true,
+            debug: debug,
         };
 
         return this.jiraClient.makeRequest(options, callback);

--- a/api/search.js
+++ b/api/search.js
@@ -55,10 +55,10 @@ function SearchClient(jiraClient) {
 
         var options = {
             uri: this.jiraClient.buildURL('/search'),
-            method: opts.method, 
+            method: opts.method,
             json: true,
-            followAllRedirects: true
-
+            followAllRedirects: true,
+            timeout: opts.timeout || 10,
         };
 
         var search_options = {

--- a/api/search.js
+++ b/api/search.js
@@ -58,7 +58,7 @@ function SearchClient(jiraClient) {
             method: opts.method,
             json: true,
             followAllRedirects: true,
-            timeout: opts.timeout || 10,
+            timeout: opts.timeout || 10000,
         };
 
         var search_options = {

--- a/index.js
+++ b/index.js
@@ -410,11 +410,9 @@ var JiraClient = module.exports = function (config) {
                                   options: options,
                                   request: {
                                     headers: requestObj._headers,
-                                    rawHeaders: requestObj._header,
                                   },
                                   response: {
                                     headers: response.headers,
-                                    rawHeaders: response.rawHeaders,
                                   },
                                 }
                               });
@@ -431,11 +429,9 @@ var JiraClient = module.exports = function (config) {
                             options: options,
                             request: {
                               headers: requestObj._headers,
-                              rawHeaders: requestObj._header,
                             },
                             response: {
                               headers: response.headers,
-                              rawHeaders: response.rawHeaders,
                             },
                           }
                         });

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ var JiraClient = module.exports = function (config) {
     this.webhookApiVersion = '1.0';
     this.promise = config.promise || Promise;
     this.requestLib = config.request || request;
+    this.rejectUnauthorized = config.rejectUnauthorized || true;
 
     if (config.oauth) {
         if (!config.oauth.consumer_key) {
@@ -332,6 +333,7 @@ var JiraClient = module.exports = function (config) {
      */
     this.makeRequest = function (options, callback, successString) {
         let requestLib = this.requestLib;
+        options.rejectUnauthorized = this.rejectUnauthorized;
 
         if (this.oauthConfig) {
             options.oauth = this.oauthConfig;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "REST",
     "OAuth"
   ],
-  "main": ".",
+  "main": "./index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "oauth": "^0.9.12",
-    "request": "^2.51.0"
+    "request": "^2.83.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added "jql" and "fields" options for "getIssuesForBoard" method. Since this method using GET request, for Oauth signature we need to use "useQuerystring" option of request package to stringify fields list correctly.