### PR TITLE
doc: added worklog endpoint to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,10 @@ is still valid!
   * getDraftWorkflow
   * editDraftWorkflow
   * deleteDraftWorkflow
+* worklog (/rest/api/2/worklog)
+  * getWorklogDeleted
+  * worklogList
+  * getWorklogUpdated
 
 ## License
 


### PR DESCRIPTION
Worklog endpoint is already supported but the information is missing in readme.