### PR TITLE
Exclude docs/ from packaged npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "REST",
     "OAuth"
   ],
+  "files": [
+    "api/",
+    "lib/",
+    "index.js",
+    "jsdoc.json"
+  ],
   "main": "./index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The way the package is currently configured, the docs/ directory is distributed with the packaged npm. This means that all projects that include jira-connector as a dependency will bundle the compiled HTML docs for all previous versions of jira-connector, too, which causes the package's bundled size to increase by roughly a factor of 100x.

Before this change:

```
$ npm pack
...
npm notice === Tarball Details ===
npm notice name:          jira-connector
npm notice version:       2.9.0
npm notice filename:      jira-connector-2.9.0.tgz
npm notice package size:  5.1 MB
npm notice unpacked size: 23.5 MB
npm notice shasum:        b1381446a9a337be1e9248723fd3cc92f7fed487
npm notice integrity:     sha512-VMQ7fGpY/HBYJ[...]wLAP2LmobCU7Q==
npm notice total files:   1167
```

After this change:

```
$ npm pack
...
npm notice === Tarball Details ===
npm notice name:          jira-connector
npm notice version:       2.9.0
npm notice filename:      jira-connector-2.9.0.tgz
npm notice package size:  45.8 kB
npm notice unpacked size: 334.2 kB
npm notice shasum:        c251ddf327faedb069051647d7112d5577500c15
npm notice integrity:     sha512-nRdu8nvstnaB4[...]9AKKDfQtNj8dw==
npm notice total files:   56
```

Note that this change still preserves the jsdoc configuration, so an end user could still generate the docs for their current version locally.

