### PR TITLE
Fix FavouriteFilter() function naming to match API name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JavaScript Jira API Wrapper for NodeJS
+/# JavaScript Jira API Wrapper for NodeJS
 
 Node.JS module which provides easy-to-use access to the Jira REST API.
 
@@ -298,7 +298,7 @@ is still valid!
   * resetFilterColumns
   * getDefaultShareScope
   * setDefaultShareScope
-  * getFavoriteFilters
+  * getFavouriteFilters
 * group (/rest/api/2/group)
   * createGroup
   * getGroup [DEPRECATED, use getMembers]

--- a/api/filter.js
+++ b/api/filter.js
@@ -227,7 +227,7 @@ function FilterClient(jiraClient) {
      * @param [callback] Called when the list of favourites has been retrieved.
      * @return {Promise} Resolved when the list of favourites has been retrieved.
      */
-    this.getFavoriteFilters = function (opts, callback) {
+    this.getFavouriteFilters = function (opts, callback) {
         var options = {
             uri: this.jiraClient.buildURL('/filter/favourite'),
             method: 'GET',


### PR DESCRIPTION
The current functon name is misleading and should match the API name.