### PR TITLE
getFavoriteFilters() -> getFavouriteFilters()

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ is still valid!
   * resetFilterColumns
   * getDefaultShareScope
   * setDefaultShareScope
-  * getFavoriteFilters
+  * getFavouriteFilters
 * group (/rest/api/2/group)
   * createGroup
   * getGroup [DEPRECATED, use getMembers]

--- a/api/filter.js
+++ b/api/filter.js
@@ -227,7 +227,7 @@ function FilterClient(jiraClient) {
      * @param [callback] Called when the list of favourites has been retrieved.
      * @return {Promise} Resolved when the list of favourites has been retrieved.
      */
-    this.getFavoriteFilters = function (opts, callback) {
+    this.getFavouriteFilters = function (opts, callback) {
         var options = {
             uri: this.jiraClient.buildURL('/filter/favourite'),
             method: 'GET',


### PR DESCRIPTION
Function naming should be consistent...