### PR TITLE
Add getReportsForBoard method

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ is still valid!
   * getEpics
   * getIssuesWithoutEpic
   * getIssuesForBoard
+  * getReportsForBoard
   * getSprintsForBoard
 * comment (/rest/api/2/comment)
   * getCommentPropertyKeys

--- a/api/board.js
+++ b/api/board.js
@@ -399,4 +399,25 @@ function AgileBoardClient(jiraClient) {
 
     return this.jiraClient.makeRequest(options, callback);
   };
+
+  /**
+   * Get reports for associated board
+   *
+   * @method getReportsForBoard
+   * @memberOf AgileBoardClient#
+   * @param {Object} opts The request options to send to the Jira API
+   * @param {number} opts.boardId The agile board id.
+   * @param {function} [callback] Called when the sprints have been retrieved.
+   * @return {Promise} Resolved when the sprints have been retrieved.
+   */
+  this.getReportsForBoard = function(opts, callback) {
+    var options = {
+      uri: this.jiraClient.buildAgileURL("/board/" + opts.boardId + "/reports"),
+      method: "GET",
+      json: true,
+      followAllRedirects: true
+    };
+
+    return this.jiraClient.makeRequest(options, callback);
+  };
 }


### PR DESCRIPTION
The method maps to the following API call: https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-board-boardId-reports-get