### PR TITLE
Custom headers allowed for addAttachment method

### DIFF
--- a/api/issue.d.ts
+++ b/api/issue.d.ts
@@ -65,4 +65,39 @@ export declare class Issue {
         increaseBy?: string,
         overrideEditableFlag?: boolean
     }, callback?: any): Promise<any>;
+
+    addAttachment(opts: {
+        filename: string | string[],
+        issueId?: string | number,
+        issueKey?: string | number,
+        headers?: {
+            'X-Atlassian-Token': any,
+            charset: string | any,
+            [key: string]: any
+        }
+    }, callback?: any): Promise<{
+        [key: string]: any,
+        self: string,
+        id: string,
+        filename: string,
+        author: {
+            self: string,
+            accountId: string,
+            emailAddress: string,
+            avatarUrls: {
+                '48x48': string,
+                '24x24': string,
+                '16x16': string,
+                '32x32': string
+            },
+            displayName: string,
+            active: boolean,
+            timeZone: string
+        },
+        created: string,
+        size: number,
+        mimeType: string,
+        content: string,
+        thumbnail: string
+    }[] | any>;
 }


### PR DESCRIPTION
Fixes for #161.

@liemnt tests required:

Install:
```bash
npm i https://github.com/floralvikings/jira-connector.git#custom-headers-for-attachment
```

Test method:
```js
jiraClient.issue.addAttachment({
  ...
  headers: {
    'X-Atlassian-Token': 'nocheck'
  }
});
```