### PR TITLE
Changed token object name to api_token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ var jira = new JiraClient({
   host: "jenjinstudios.atlassian.net",
   basic_auth: {
     email: "email@email.com",
-    token: "api-token"
+    api_token: "api-token"
   }
 });
 ```


### PR DESCRIPTION
I'm testing the basic authentication with basic token and I'm seeing errors like so below:

2019-06-25T13:09:40.232Z	807fc98a-bb25-48a1-9e40-423d5d4215fe	Error: Missing 'api_token' property.
    at new module.exports (/var/task/node_modules/jira-connector/index.js:194:23)
    at module.exports.jiratest (/var/task/handler.js:22:14)

I checked the code and it is indeed looking for 'api_token' instead of 'token'

Theres two ways to change this, either change the code or change the readme, I chose the easier route.