### PR TITLE
Add basic type definitions for sprint api

### DIFF
--- a/api/sprint.d.ts
+++ b/api/sprint.d.ts
@@ -2,7 +2,7 @@ import { JiraSprint, Callback } from '../index';
 
 type SprintId = string | number;
 
-export declare class Sprint {
+declare class AgileSprintClient {
     createSprint(
         sprint: Pick<
             JiraSprint,
@@ -70,3 +70,5 @@ export declare class Sprint {
         callback?: Callback
     ): Promise<any>;
 }
+
+export = AgileSprintClient

--- a/api/sprint.d.ts
+++ b/api/sprint.d.ts
@@ -1,4 +1,4 @@
-import { JiraSprint } from '../index';
+import { JiraSprint, Callback } from '../index';
 
 type SprintId = string | number;
 
@@ -12,7 +12,7 @@ export declare class Sprint {
             | 'originBoardId'
             | 'goal'
         >,
-        callback?: any
+        callback?: Callback
     ): Promise<any>;
     getSprint(
         opts: {
@@ -21,15 +21,15 @@ export declare class Sprint {
             startAt?: number;
             maxResults?: number;
         },
-        callback?: any
+        callback?: Callback<JiraSprint>
     ): Promise<JiraSprint>;
     updateSprint(
         opts: { sprintId: SprintId } & Partial<JiraSprint>,
-        callback?: any
+        callback?: Callback<JiraSprint>
     ): Promise<JiraSprint>;
     partiallyUpdateSprint(
         opts: { sprintId: SprintId } & Partial<JiraSprint>,
-        callback?: any
+        callback?: Callback<JiraSprint>
     ): Promise<JiraSprint>;
     deleteSprint(
         opts: {
@@ -38,7 +38,7 @@ export declare class Sprint {
             startAt?: number;
             maxResults?: number;
         },
-        callback?: any
+        callback?: Callback
     ): Promise<any>;
     getSprintIssues(
         opts: {
@@ -50,7 +50,7 @@ export declare class Sprint {
             fields?: string[];
             expand?: string;
         },
-        callback?: any
+        callback?: Callback
     ): Promise<any>;
     moveSprintIssues(
         opts: {
@@ -60,13 +60,13 @@ export declare class Sprint {
             rankAfterIssue?: string;
             rankCustomFieldId?: string;
         },
-        callback?: any
+        callback?: Callback
     ): Promise<any>;
     swapSprint(
         opts: {
             sprintId: SprintId;
             sprintToSwapWith: string;
         },
-        callback?: any
+        callback?: Callback
     ): Promise<any>;
 }

--- a/api/sprint.d.ts
+++ b/api/sprint.d.ts
@@ -1,0 +1,72 @@
+import { JiraSprint } from '../index';
+
+type SprintId = string | number;
+
+export declare class Sprint {
+    createSprint(
+        sprint: Pick<
+            JiraSprint,
+            | 'name' //
+            | 'startDate'
+            | 'endDate'
+            | 'originBoardId'
+            | 'goal'
+        >,
+        callback?: any
+    ): Promise<any>;
+    getSprint(
+        opts: {
+            sprintId: SprintId;
+            filter?: number;
+            startAt?: number;
+            maxResults?: number;
+        },
+        callback?: any
+    ): Promise<JiraSprint>;
+    updateSprint(
+        opts: { sprintId: SprintId } & Partial<JiraSprint>,
+        callback?: any
+    ): Promise<JiraSprint>;
+    partiallyUpdateSprint(
+        opts: { sprintId: SprintId } & Partial<JiraSprint>,
+        callback?: any
+    ): Promise<JiraSprint>;
+    deleteSprint(
+        opts: {
+            sprintId: SprintId;
+            filter?: number;
+            startAt?: number;
+            maxResults?: number;
+        },
+        callback?: any
+    ): Promise<any>;
+    getSprintIssues(
+        opts: {
+            sprintId: SprintId;
+            startAt?: number;
+            maxResults?: number;
+            jql?: string;
+            validateQuery?: boolean;
+            fields?: string[];
+            expand?: string;
+        },
+        callback?: any
+    ): Promise<any>;
+    moveSprintIssues(
+        opts: {
+            sprintId: SprintId;
+            issues: string[];
+            rankBeforeIssue?: string;
+            rankAfterIssue?: string;
+            rankCustomFieldId?: string;
+        },
+        callback?: any
+    ): Promise<any>;
+    swapSprint(
+        opts: {
+            sprintId: SprintId;
+            sprintToSwapWith: string;
+        },
+        callback?: any
+    ): Promise<any>;
+}

--- a/api/sprint.js
+++ b/api/sprint.js
@@ -38,7 +38,10 @@ function AgileSprintClient(jiraClient) {
    * @method getSprint
    * @memberOf AgileSprintClient#
    * @param {object} opts The request options sent to the Jira API.
-   * @param opts.sprintId The sprint id.
+   * @param {string} opts.sprintId The sprint id.
+   * @param {string} [opts.filter]
+   * @param {string} [opts.startAt]
+   * @param {string} [opts.maxResults]
    * @param [callback] Called when the sprint has been retrieved.
    * @return {Promise} Resolved when the sprint has been retrieved.
    */
@@ -65,7 +68,7 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {Object} sprint The sprint data in the form of PUT body to the
    *   Jira API.
-   * @param {string} [sprint.sprintId] The id of the sprint.  EX: 331
+   * @param {string} sprint.sprintId The id of the sprint.  EX: 331
    * @param [callback] Called when the sprint has been updated.
    * @return {Promise} Resolved when the sprint has been updated.
    */
@@ -92,7 +95,7 @@ function AgileSprintClient(jiraClient) {
    * @param {Object} sprint The sprint data in the form of POST body to the
    *   Jira API.
    * @param {string} [sprint.sprintId] The id of the sprint.  EX: 331.
-   * @param callback Called when the sprint has been updated.
+   * @param [callback] Called when the sprint has been updated.
    * @return {Promise} Resolved when the sprint has been updated.
    */
   this.partiallyUpdateSprint = function (sprint, callback) {
@@ -117,6 +120,9 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {Object} opts The request options sent to the Jira API.
    * @param {string} opts.sprintId The id of the sprint.  EX: 331
+   * @param {string} [opts.filter]
+   * @param {string} [opts.startAt]
+   * @param {string} [opts.maxResults]
    * @param [callback] Called when the sprint is deleted.
    * @return {Promise} Resolved when the sprint is deleted.
    */
@@ -142,11 +148,13 @@ function AgileSprintClient(jiraClient) {
    * @method getSprintIssues
    * @memberOf AgileSprintClient#
    * @param {Object} opts The request options sent to the Jira API.
-   * @param opts.sprintId The sprint id.
-   * @param {string} jql Filters results using a JQL query.
-   * @param {boolean} validateQuery Specifies whether to valide the JQL query.
-   * @param {string} fields The list of fields to return for each issue.
-   * @param {string} expand A comma-separated list of the parameters to expand.
+   * @param {string} opts.sprintId The sprint id.
+   * @param {string} [opts.startAt]
+   * @param {string} [opts.maxResults]
+   * @param {string} [opts.jql] Filters results using a JQL query.
+   * @param {boolean} [opts.validateQuery] Specifies whether to valide the JQL query.
+   * @param {string} [opts.fields] The list of fields to return for each issue.
+   * @param {string} [opts.expand] A comma-separated list of the parameters to expand.
    * @param [callback] Called when the issues are returned.
    * @return {Promise} Resolved when the issues are returned.
    */
@@ -176,7 +184,11 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {Object} opts The issue data in the form of POST body to the
    *   Jira API.
-   * @param {string} [opts.sprintId] The sprint id.
+   * @param {string} opts.sprintId The sprint id.
+   * @param {string[]} opts.issues Ids of the issues to move.
+   * @param {string} [opts.rankBeforeIssue]
+   * @param {string} [opts.rankAfterIssue]
+   * @param {string} [opts.rankCustomField]
    * @param [callback] Called when the sprint has been retrieved.
    * @return {Promise} Resolved when the sprint has been retrieved.
    */
@@ -201,21 +213,22 @@ function AgileSprintClient(jiraClient) {
    *
    * @method swapSprint
    * @memberOf AgileSprintClient#
-   * @param {Object} swapped The data in the form of POST body to the Jira API.
-   * @param {string} [swapped.sprintId] The id of the sprint.  EX: 311
-   * @param [callback] Called when the sprint has been retrived.
-   * @return {Promise} Resolved when the sprint has been retrived.
+   * @param {Object} opts The data in the form of POST body to the Jira API.
+   * @param {string} opts.sprintId The id of the sprint.  EX: 311
+   * @param {string} opts.sprintToSwapWith The id of the sprint.  EX: 311
+   * @param [callback] Called when the sprint has been retrieved.
+   * @return {Promise} Resolved when the sprint has been retrieved.
    */
-  this.swapSprint = function (swapped, callback) {
-    var sprintId = swapped.sprintId;
-    delete swapped.sprintId;
+  this.swapSprint = function (opts, callback) {
+    var sprintId = opts.sprintId;
+    delete opts.sprintId;
 
     var options = {
       uri: this.jiraClient.buildAgileURL('/sprint/' + sprintId + '/swap'),
       method: 'POST',
       followAllRedirects: true,
       json: true,
-      body: swapped
+      body: opts
     };
 
     return this.jiraClient.makeRequest(options, callback);

--- a/api/sprint.js
+++ b/api/sprint.js
@@ -17,7 +17,7 @@ function AgileSprintClient(jiraClient) {
    * @memberOf AgileSprintClient#
    * @param {Object} sprint The sprint data in the form of POST body to the
    *   Jira API.
-   * @param [callback] Called when the sprint has been created.
+   * @param {callback} [callback] Called when the sprint has been created.
    * @return {Promise} Resolved when the sprint has been created.
    */
   this.createSprint = function (sprint, callback) {
@@ -42,7 +42,7 @@ function AgileSprintClient(jiraClient) {
    * @param {string} [opts.filter]
    * @param {string} [opts.startAt]
    * @param {string} [opts.maxResults]
-   * @param [callback] Called when the sprint has been retrieved.
+   * @param {callback} [callback] Called when the sprint has been retrieved.
    * @return {Promise} Resolved when the sprint has been retrieved.
    */
   this.getSprint = function (opts, callback) {
@@ -69,7 +69,7 @@ function AgileSprintClient(jiraClient) {
    * @param {Object} sprint The sprint data in the form of PUT body to the
    *   Jira API.
    * @param {string} sprint.sprintId The id of the sprint.  EX: 331
-   * @param [callback] Called when the sprint has been updated.
+   * @param {callback} [callback] Called when the sprint has been updated.
    * @return {Promise} Resolved when the sprint has been updated.
    */
   this.updateSprint = function (sprint, callback) {
@@ -95,7 +95,7 @@ function AgileSprintClient(jiraClient) {
    * @param {Object} sprint The sprint data in the form of POST body to the
    *   Jira API.
    * @param {string} [sprint.sprintId] The id of the sprint.  EX: 331.
-   * @param [callback] Called when the sprint has been updated.
+   * @param {callback} [callback] Called when the sprint has been updated.
    * @return {Promise} Resolved when the sprint has been updated.
    */
   this.partiallyUpdateSprint = function (sprint, callback) {
@@ -123,7 +123,7 @@ function AgileSprintClient(jiraClient) {
    * @param {string} [opts.filter]
    * @param {string} [opts.startAt]
    * @param {string} [opts.maxResults]
-   * @param [callback] Called when the sprint is deleted.
+   * @param {callback} [callback] Called when the sprint is deleted.
    * @return {Promise} Resolved when the sprint is deleted.
    */
   this.deleteSprint = function (opts, callback) {
@@ -155,7 +155,7 @@ function AgileSprintClient(jiraClient) {
    * @param {boolean} [opts.validateQuery] Specifies whether to valide the JQL query.
    * @param {string} [opts.fields] The list of fields to return for each issue.
    * @param {string} [opts.expand] A comma-separated list of the parameters to expand.
-   * @param [callback] Called when the issues are returned.
+   * @param {callback} [callback] Called when the issues are returned.
    * @return {Promise} Resolved when the issues are returned.
    */
   this.getSprintIssues = function (opts, callback) {
@@ -189,7 +189,7 @@ function AgileSprintClient(jiraClient) {
    * @param {string} [opts.rankBeforeIssue]
    * @param {string} [opts.rankAfterIssue]
    * @param {string} [opts.rankCustomField]
-   * @param [callback] Called when the sprint has been retrieved.
+   * @param {callback} [callback] Called when the sprint has been retrieved.
    * @return {Promise} Resolved when the sprint has been retrieved.
    */
   this.moveSprintIssues = function (opts, callback) {
@@ -216,7 +216,7 @@ function AgileSprintClient(jiraClient) {
    * @param {Object} opts The data in the form of POST body to the Jira API.
    * @param {string} opts.sprintId The id of the sprint.  EX: 311
    * @param {string} opts.sprintToSwapWith The id of the sprint.  EX: 311
-   * @param [callback] Called when the sprint has been retrieved.
+   * @param {callback} [callback] Called when the sprint has been retrieved.
    * @return {Promise} Resolved when the sprint has been retrieved.
    */
   this.swapSprint = function (opts, callback) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import { Board } from './api/board';
 import { Epic } from './api/epic';
 import { Issue } from './api/issue';
 import { Project } from './api/project';
+import { Sprint } from './api/sprint';
 import { User } from './api/user';
 import { Search } from './api/search';
 import IssueTypeClient = require('./api/issueType');
@@ -84,7 +85,7 @@ declare class JiraClient {
     public securityLevel: any;
     public serverInfo: any;
     public settings: any;
-    public sprint: any;
+    public sprint: Sprint;
     public status: any;
     public statusCategory: any;
     public user: User;
@@ -125,5 +126,17 @@ declare namespace JiraClient {
     export interface JiraProjectScope {
         type: 'PROJECT';
         project: { id: string };
+    }
+
+    export interface JiraSprint {
+        id: string;
+        self: string;
+        state: 'active' | 'closed' | 'future';
+        name: string;
+        startDate: string;
+        endDate: string;
+        originBoardId: number;
+        goal: string;
+        completeDate?: string;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -109,6 +109,8 @@ declare namespace JiraClient {
         function swapRequestTokenWithAccessToken(config: any, callback: any): void;
     }
 
+    export type Callback<TData = any> = (err: any, data: TData) => void;
+
     export interface JiraIssueType {
         self: string;
         id: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { Board } from './api/board';
 import { Epic } from './api/epic';
 import { Issue } from './api/issue';
 import { Project } from './api/project';
-import { Sprint } from './api/sprint';
+import AgileSprintClient = require('./api/sprint');
 import { User } from './api/user';
 import { Search } from './api/search';
 import IssueTypeClient = require('./api/issueType');
@@ -85,7 +85,7 @@ declare class JiraClient {
     public securityLevel: any;
     public serverInfo: any;
     public settings: any;
-    public sprint: Sprint;
+    public sprint: AgileSprintClient;
     public status: any;
     public statusCategory: any;
     public user: User;


### PR DESCRIPTION
Basic type definitions for `sprint`. Also adjusted the JSDocs, and renamed `swapped` parameter of `#swapSprint` to `opts` for consistency.