### PR TITLE
config option to enable GDPR compliant API

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,7 @@ var worklog = require('./api/worklog');
  *      Default - native Promise.
  * @param {Request} [config.request] Any function (constructor) compatible with Request (request, supertest,...).
  *      Default - require('request').
+ * @param {boolean} [config.forceGDPRCompliantAPI] Whether or not to force REST APIs to only use GDPR-compliant functionality
  */
 
 var JiraClient = module.exports = function (config) {
@@ -184,6 +185,7 @@ var JiraClient = module.exports = function (config) {
     this.promise = config.promise || Promise;
     this.requestLib = config.request || request;
     this.rejectUnauthorized = config.rejectUnauthorized;
+    this.forceGDPRCompliantAPI = !!config.forceGDPRCompliantAPI;
 
     if (config.oauth) {
         if (!config.oauth.consumer_key) {
@@ -462,6 +464,13 @@ var JiraClient = module.exports = function (config) {
 
         if (this.cookie_jar) {
             options.jar = this.cookie_jar;
+        }
+
+        if (this.forceGDPRCompliantAPI) {
+            if (!options.headers) {
+                options.headers = {};
+            }
+            options.headers['x-atlassian-force-account-id'] = true;
         }
 
         if (callback) {

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -30,4 +30,5 @@ export interface Config {
   promise?: PromiseLike<any>;
   request?: any;
   rejectUnauthorized?: any;
+  forceGDPRCompliantAPI?: boolean;
 }


### PR DESCRIPTION
As we know, Atlassian is in the process of changing and deprecating some API behavior to better comply with GDPR, they started by removing personal user data and adding accountIds instead.
Some APIs still return old user data but we can't know for sure when APIs will be completely changed.
Luckily, Atlassian has provided us with a way to test these changes and prepare.

This can be done by sending an HTTP header alongside requests (see [here](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/#testing-your-gdpr-changes)), which this PR enables.

You can read [here](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) for other changes being performed, although it seems the announcement is pretty old