### PR TITLE
add webhookURI to opts in webhook apis

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -37,7 +37,8 @@ function WebhookClient(jiraClient) {
      * @method getWebhook
      * @memberOf WebhookClient#
      * @param opts The options sent to the JIRA API.
-     * @param opts.webhookId The numerical webhook ID.
+     * @param opts.webhookURI The URI of the webhook to delete.
+     * @param opts.webhookId The numerical webhook ID. This is only used if webhookURI is falsey.
      * @param [callback] Called when the webhook has been retrieved.
      * @return {Promise} Resolved when the webhook has been retrieved.
      */
@@ -87,9 +88,10 @@ function WebhookClient(jiraClient) {
      * @method deleteWebhook
      * @memberOf WebhookClient#
      * @param opts The options sent to the JIRA API.
-     * @param opts.webhookId The numerical webhook ID.
-     * @param [callback] Called when the webhook has been retrieved.
-     * @return {Promise} Resolved when the webhook has been retrieved.
+     * @param opts.webhookURI The URI of the webhook to delete.
+     * @param opts.webhookId The numerical webhook ID. This is only used if webhookURI is falsey.
+     * @param [callback] Called when the webhook has been deleted.
+     * @return {Promise} Resolved when the webhook has been deleted.
      */
     this.deleteWebhook = function (opts, callback) {
         var options = {

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -43,7 +43,7 @@ function WebhookClient(jiraClient) {
      */
     this.getWebhook = function (opts, callback) {
         var options = {
-            uri: this.jiraClient.buildWebhookURL('/webhook/' + opts.webhookId),
+            uri: opts.webhookURI || this.jiraClient.buildWebhookURL('/webhook/' + opts.webhookId),
             method: 'GET',
             json: true,
             followAllRedirects: true
@@ -93,7 +93,7 @@ function WebhookClient(jiraClient) {
      */
     this.deleteWebhook = function (opts, callback) {
         var options = {
-            uri: this.jiraClient.buildWebhookURL('/webhook/' + opts.webhookId),
+            uri: opts.webhookURI || this.jiraClient.buildWebhookURL('/webhook/' + opts.webhookId),
             method: 'DELETE',
             json: true,
             followAllRedirects: true


### PR DESCRIPTION
The webhook part of this lib uses the 1.0 version REST APIs. The 1.0 version of the `createWebhook` API  doesn't return a `webhookId`, but a `self` field that includes the entire URI. This PR makes it possible to use that in other calls so one doesn't have to parse the `webhookId` out of the URI.