### PR TITLE
fix: non empty body results in content-length=2  header in request, failing api calls

### DIFF
--- a/api/comment.js
+++ b/api/comment.js
@@ -111,7 +111,6 @@ function CommentClient(jiraClient) {
         }
         var basePath = '/comment/' + opts.commentId + "/properties";
         if (!qs) qs = {};
-        if (!body) body = {};
 
         if (opts.fields) {
             qs.fields = '';

--- a/api/filter.js
+++ b/api/filter.js
@@ -256,7 +256,6 @@ function FilterClient(jiraClient) {
     this.buildRequestOptions = function (opts, path, method, body, qs) {
         var basePath = '/filter/' + opts.filterId;
         if (!qs) qs = {};
-        if (!body) body = {};
 
         if (opts.fields) {
             qs.fields = '';

--- a/api/issue.js
+++ b/api/issue.js
@@ -1298,7 +1298,6 @@ function IssueClient(jiraClient) {
         var idOrKey = opts.issueId || opts.issueKey;
         var basePath = '/issue/' + idOrKey;
         if (!qs) qs = {};
-        if (!body) body = {};
 
         if (opts.fields) {
             qs.fields = '';

--- a/api/project.js
+++ b/api/project.js
@@ -299,7 +299,6 @@ function ProjectClient(jiraClient) {
         var basePath = opts.projectIdOrKey ? '/project/' + opts.projectIdOrKey : '/project';
 
         if (!qs) qs = {};
-        if (!body) body = {};
 
         if (opts.fields) {
             qs.fields = '';

--- a/api/screens.js
+++ b/api/screens.js
@@ -220,7 +220,6 @@ function ScreensClient(jiraClient) {
     this.buildRequestOptions = function (opts, path, method, body, qs) {
         var basePath = '/screens/' + opts.screenId;
         if (!qs) qs = {};
-        if (!body) body = {};
 
         if (opts.fields) {
             qs.fields = '';

--- a/api/version.js
+++ b/api/version.js
@@ -293,7 +293,6 @@ function VersionClient(jiraClient) {
     this.buildRequestOptions = function (opts, path, method, body, qs) {
         var basePath = '/version/' + opts.versionId;
         if (!qs) qs = {};
-        if (!body) body = {};
 
         if (opts.fields) {
             qs.fields = '';

--- a/api/workflowScheme.js
+++ b/api/workflowScheme.js
@@ -490,7 +490,6 @@ function WorkflowSchemeClient(jiraClient) {
     this.buildRequestOptions = function (opts, path, method, body, qs) {
         var basePath = '/workflowscheme/' + opts.workflowSchemeId;
         if (!qs) qs = {};
-        if (!body) body = {};
 
         if (opts.fields) {
             qs.fields = '';


### PR DESCRIPTION
{} is treated as a non empty body by the request library, adding a content-length=2 header to requests that should not have a body.
This results in failed JIRA requests.

An example is the project getVersions request:
jira.project.getVersions({ projectIdOrKey: project }) with a given project fails due to the content-length headers being added.